### PR TITLE
Force discord to see new OG Image

### DIFF
--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -90,14 +90,14 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						property: 'og:image',
-						content: `${site}og.png?v=1`,
+						content: `${site}og.png?v=2`,
 					},
 				},
 				{
 					tag: 'meta',
 					attrs: {
 						property: 'twitter:image',
-						content: `${site}og.png?v=1`,
+						content: `${site}og.png?v=2`,
 					},
 				},
 				{


### PR DESCRIPTION
This pull request includes a small change to the `docs/astro.config.mts` file. The change updates the version of the Open Graph and Twitter image URLs.

* [`docs/astro.config.mts`](diffhunk://#diff-4919135145bb2f879825a0e1035443ac45a54466c6efe2756da1c7f6b5bb9ed4L93-R100): Updated the `og:image` and `twitter:image` URLs to use version 2 of the image.