### PR TITLE
Remove deprecated workflow, and update publish config and files include

### DIFF
--- a/.changeset/rich-melons-vanish.md
+++ b/.changeset/rich-melons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Update publish config and files included

--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -75,17 +75,6 @@ jobs:
           env:
             PR_URL: ${{ steps.changesets.outputs.pull_request_url }}
             GITHUB_TOKEN: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
-
-        - name: Create Sentry release
-          if: steps.changesets.outputs.published == 'true'
-          uses: getsentry/action-release@v1
-          env:
-            SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-            SENTRY_ORG: withstudiocms
-            SENTRY_URL: https://sentry.studiocms.dev/
-          with:
-            environment: production
-            projects: ui-testing
           
     mergebot:
       if: ${{ github.repository_owner == 'withstudiocms' && github.event_name == 'push' && github.event.commits[0].message != '[ci] lint' && github.event.commits[0].author.username != 'dependabot[bot]' }}

--- a/packages/studiocms_ui/package.json
+++ b/packages/studiocms_ui/package.json
@@ -26,12 +26,12 @@
   ],
   "homepage": "https://ui.studiocms.dev",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "sideEffects": false,
   "files": [
-    "dist",
-    "assets"
+    "dist"
   ],
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This pull request includes changes to the CI workflow and the `package.json` file for the `studiocms_ui` package. The most important changes involve the removal of the Sentry release step from the CI workflow and updates to the `publishConfig` and `files` sections in the `package.json` file.

CI workflow changes:

* [`.github/workflows/ci-push-main.yml`](diffhunk://#diff-33ba2fe1c42a4f2840fedd78cc4f69a10dc97c7ea276965db40186dd2795b8f1L79-L89): Removed the Sentry release step that was conditioned on changesets being published.

Package configuration updates:

* [`packages/studiocms_ui/package.json`](diffhunk://#diff-b558d641ba3c73700097cf4ecb8c5fa0e1df5f2ae65f03fd17141cd0547d267eL29-R34): Added `"provenance": true` to the `publishConfig` section.
* [`packages/studiocms_ui/package.json`](diffhunk://#diff-b558d641ba3c73700097cf4ecb8c5fa0e1df5f2ae65f03fd17141cd0547d267eL29-R34): Removed the `assets` directory from the `files` section.