### PR TITLE
Update Input component to allow search type

### DIFF
--- a/.changeset/fast-bears-clean.md
+++ b/.changeset/fast-bears-clean.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Update Input component to allow search type

--- a/packages/studiocms_ui/src/components/Input/Input.astro
+++ b/packages/studiocms_ui/src/components/Input/Input.astro
@@ -14,7 +14,7 @@ interface Props extends HTMLAttributes<'input'> {
 	/**
 	 * The type of the input. Defaults to `text`.
 	 */
-	type?: 'text' | 'password' | 'email' | 'number' | 'tel' | 'url';
+	type?: 'text' | 'password' | 'email' | 'number' | 'tel' | 'url' | 'search';
 	/**
 	 * The placeholder of the input.
 	 */


### PR DESCRIPTION
This pull request includes a small change to the `Input` component in the `studiocms_ui` package. The change adds a new input type option to the `Props` interface.

* [`packages/studiocms_ui/src/components/Input/Input.astro`](diffhunk://#diff-67687c2ca0b7aa7f580d66be4b332e3430f7c189fcf3de0abeafc8b830d8d97bL17-R17): Added 'search' as an option for the `type` property in the `Props` interface.

This is a valid type as per MDN