### PR TITLE
Update index.mdx to point to the right github url

### DIFF
--- a/docs/src/content/docs/docs/index.mdx
+++ b/docs/src/content/docs/docs/index.mdx
@@ -5,7 +5,7 @@ description: Install @studiocms/ui in your own project and make use of our compo
 type: integration
 integration:
   name: "@studiocms/ui"
-  githubURL: "https://github.com/withstudiocms/ui/tree/next/packages/studiocms_ui"
+  githubURL: "https://github.com/withstudiocms/ui/tree/main/packages/studiocms_ui"
 ---
 
 import { PackageManagers } from 'starlight-package-managers'


### PR DESCRIPTION
This pull request includes a small but important change to the `docs/src/content/docs/docs/index.mdx` file. The change updates the GitHub URL for the `@studiocms/ui` package to point to the `main` branch instead of the `next` branch.

* [`docs/src/content/docs/docs/index.mdx`](diffhunk://#diff-ce89d0987a321cca43d8c04121a47e2129aab6746465d91afc7f8832ddc849bdL8-R8): Updated the GitHub URL for the `@studiocms/ui` package to point to the `main` branch.