### PR TITLE
Allow users to import the globalCSS themselves

### DIFF
--- a/.changeset/kind-olives-cross.md
+++ b/.changeset/kind-olives-cross.md
@@ -1,0 +1,12 @@
+---
+"@studiocms/ui": patch
+---
+
+Add option to disable global CSS injection and allow users to import the global css themselves.
+
+Basic Example of how to import:
+```astro
+---
+import "studiocms:ui/global-css";
+---
+```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "themetoggle",
     "Thum",
     "tsconfigs",
+    "twoslash",
     "vite",
     "withstudiocms"
   ]

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -22,7 +22,7 @@ pnpm-debug.log*
 .DS_Store
 
 # Changelog documentation
-src/content/docs/docs/changelog.md
+docs/changelog.md
 
 # Eleventy cache
 .cache/

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "@types/mdast": "^4.0.4",
     "astro": "catalog:",
     "astro-embed": "^0.9.0",
-    "expressive-code-twoslash": "^0.3.0",
+    "expressive-code-twoslash": "^0.3.1",
     "hast": "1.0.0",
     "hast-util-select": "^6.0.3",
     "hast-util-to-string": "^3.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "pnpm make-changelog && astro dev",
+    "dev": "astro dev",
     "start": "pnpm dev",
     "check": "astro check",
     "build": "pnpm make-changelog && astro build",

--- a/docs/src/content/docs/docs/changelog.md
+++ b/docs/src/content/docs/docs/changelog.md
@@ -8,6 +8,26 @@ editUrl: false
 This document contains release notes for the `@studiocms/ui` package.
 For more information, see the [CHANGELOG file](https://github.com/withstudiocms/ui/blob/main/packages/studiocms_ui/CHANGELOG.md)
 
+## 0.4.6
+
+- [#52](https://github.com/withstudiocms/ui/pull/52) [`65eea2c`](https://github.com/withstudiocms/ui/commit/65eea2cff78c2c38314de9b3fe4b65173c81ea90) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Update Input component to allow search type
+
+## 0.4.5
+
+- [#50](https://github.com/withstudiocms/ui/pull/50) [`51d5565`](https://github.com/withstudiocms/ui/commit/51d556504790741ad3b6cd23092b9be0a92e8157) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - fix weird icon sizing during build
+
+## 0.4.4
+
+- [#48](https://github.com/withstudiocms/ui/pull/48) [`4a43e03`](https://github.com/withstudiocms/ui/commit/4a43e031b2395ca1cf72c8343638f5836178944e) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Fix Icon component requiring functions from Iconify Utils lib during runtime as well as extend usage possibilities.
+
+  NEW:
+
+  - `IconBase` component exported from `studiocms:ui/components` which allows passing custom image collections from Iconify.
+
+  Updated:
+
+  - `Icon` component to use this new system.
+
 ## 0.4.3
 
 - [#46](https://github.com/withstudiocms/ui/pull/46) [`29ea967`](https://github.com/withstudiocms/ui/commit/29ea967c2cee935715de0f4787b603d69997e84b) Thanks [@louisescher](https://github.com/louisescher)! - Fixes icons getting cut off in certain circumstances and changes dropdown links to include icons

--- a/docs/src/content/docs/docs/guides/customization.mdx
+++ b/docs/src/content/docs/docs/guides/customization.mdx
@@ -45,7 +45,7 @@ HSL values without commas. You can use them in your CSS like this: `background-c
 
 If you want to disable the CSS injection, you can do so by setting the `noInjectCSS` option to `true`:
 
-```ts showLinenumbers title="astro.config.mjs" {7}
+```ts twoslash showLinenumbers title="astro.config.mjs" {7}
 import { defineConfig } from 'astro/config';
 import ui from '@studiocms/ui';
 

--- a/docs/src/content/docs/docs/guides/customization.mdx
+++ b/docs/src/content/docs/docs/guides/customization.mdx
@@ -41,6 +41,35 @@ If you make significant changes to the colors, remember to also adjust the light
 Below, you will find all the CSS variables used in StudioCMS UI. Always make sure to provide them as 
 HSL values without commas. You can use them in your CSS like this: `background-color: hsl(var(--background-base));`.
 
+## Disabling CSS Injection
+
+If you want to disable the CSS injection, you can do so by setting the `noInjectCSS` option to `true`:
+
+```ts showLinenumbers title="astro.config.mjs" {7}
+import { defineConfig } from 'astro/config';
+import ui from '@studiocms/ui';
+
+export default defineConfig({
+  integrations: [
+    ui({
+      noInjectCSS: true,
+    })
+  ]
+});
+```
+
+You can then include the CSS in your project manually. (Useful if you want to mix studiocms-ui with other CSS frameworks. or if you are using the UI styling only for a subset of your components.)
+
+```astro showLinenumbers title="src/layouts/SUILayout.astro"
+---
+// Relying on the Virtual module to import the CSS file (recommended)
+import "studiocms:ui/global-css";
+
+// Or import the CSS file directly from the package
+import "@studiocms/ui/css/global.css";
+---
+```
+
 ## Interactive Editing
 
 You can edit the colors in your own project during development using the dev toolbar. In the toolbar, you will find a 

--- a/docs/src/content/docs/docs/guides/customization.mdx
+++ b/docs/src/content/docs/docs/guides/customization.mdx
@@ -58,14 +58,14 @@ export default defineConfig({
 });
 ```
 
-You can then include the CSS in your project manually. (Useful if you want to mix studiocms-ui with other CSS frameworks. or if you are using the UI styling only for a subset of your components.)
+You can then include the CSS in your project manually. This is useful if you want to mix StudioCMS UI with other CSS frameworks, or if you are using the UI styling only for a subset of your components.
 
 ```astro showLinenumbers title="src/layouts/SUILayout.astro"
 ---
-// Relying on the Virtual module to import the CSS file (recommended)
+// Using the virtual module to import the CSS file (recommended)
 import "studiocms:ui/global-css";
 
-// Or import the CSS file directly from the package
+// Alternatively, import the CSS file directly from the package
 import "@studiocms/ui/css/global.css";
 ---
 ```

--- a/packages/studiocms_ui/src/index.ts
+++ b/packages/studiocms_ui/src/index.ts
@@ -15,11 +15,13 @@ type Options = {
 	customCss?: string;
 
 	/**
- 	 * Disable CSS Generation and require manual addition of the global CSS
-   	 * 
-         * @example
+	 * Disable CSS Generation and require manual addition of the global CSS
+	 *
+	 * @example
+	 * ```ts
 	 * import 'studiocms:ui/global-css';
-   	 */
+	 * ```
+	 */
 	noInjectCSS?: boolean;
 };
 
@@ -107,7 +109,7 @@ export default function integration(options: Options = {}): AstroIntegration {
 				});
 
 				if (!options.noInjectCSS) {
-				    injectScript('page-ssr', `import 'studiocms:ui/global-css';`);
+					injectScript('page-ssr', `import 'studiocms:ui/global-css';`);
 				}
 
 				if (options.customCss) {

--- a/packages/studiocms_ui/src/index.ts
+++ b/packages/studiocms_ui/src/index.ts
@@ -106,7 +106,7 @@ export default function integration(options: Options = {}): AstroIntegration {
 					},
 				});
 
-				if (!noInjectCSS) {
+				if (!options.noInjectCSS) {
 				    injectScript('page-ssr', `import 'studiocms:ui/global-css';`);
 				}
 

--- a/packages/studiocms_ui/src/index.ts
+++ b/packages/studiocms_ui/src/index.ts
@@ -13,6 +13,14 @@ type Options = {
 	 * @link https://ui.studiocms.dev/docs/guides/customization/
 	 */
 	customCss?: string;
+
+	/**
+ 	 * Disable CSS Generation and require manual addition of the global CSS
+   	 * 
+         * @example
+	 * import 'studiocms:ui/global-css';
+   	 */
+	noInjectCSS?: boolean;
 };
 
 export default function integration(options: Options = {}): AstroIntegration {
@@ -98,7 +106,9 @@ export default function integration(options: Options = {}): AstroIntegration {
 					},
 				});
 
-				injectScript('page-ssr', `import 'studiocms:ui/global-css';`);
+				if (!noInjectCSS) {
+				    injectScript('page-ssr', `import 'studiocms:ui/global-css';`);
+				}
 
 				if (options.customCss) {
 					injectScript('page-ssr', `import 'studiocms:ui/custom-css';`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0(astro@5.1.1(@types/node@20.17.10)(jiti@2.3.3)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))
       expressive-code-twoslash:
-        specifier: ^0.3.0
-        version: 0.3.0(@expressive-code/core@0.38.3)(expressive-code@0.38.3)(typescript@5.7.2)
+        specifier: ^0.3.1
+        version: 0.3.1(@expressive-code/core@0.38.3)(expressive-code@0.38.3)(typescript@5.7.2)
       hast:
         specifier: 1.0.0
         version: 1.0.0
@@ -1979,8 +1979,8 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
-  expressive-code-twoslash@0.3.0:
-    resolution: {integrity: sha512-adEOcFTRlNK3mnyi31cEWXEIP+anlZNHmMijTPdv4RVTqjs2qDlt591xntPvlH7YJSfypEw+c3teWOzelNxbvA==}
+  expressive-code-twoslash@0.3.1:
+    resolution: {integrity: sha512-soC622FPOekEvQoYGr2C5yTIazZfsVAEcz8wpVORt9erxEOxMTVg045g0Zqa2X15DgnprUZAzBp9w+T5FFEvWg==}
     peerDependencies:
       '@expressive-code/core': ^0.38.3
       expressive-code: ^0.38.3
@@ -5528,7 +5528,7 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  expressive-code-twoslash@0.3.0(@expressive-code/core@0.38.3)(expressive-code@0.38.3)(typescript@5.7.2):
+  expressive-code-twoslash@0.3.1(@expressive-code/core@0.38.3)(expressive-code@0.38.3)(typescript@5.7.2):
     dependencies:
       '@expressive-code/core': 0.38.3
       expressive-code: 0.38.3


### PR DESCRIPTION
This pull request introduces a new option to the `integration` function in the `packages/studiocms_ui/src/index.ts` file, allowing users to disable automatic CSS injection. The most important changes include adding the `noInjectCSS` option to the `Options` type and modifying the CSS injection logic accordingly.

Enhancements to CSS injection:

* [`packages/studiocms_ui/src/index.ts`](diffhunk://#diff-238aaddf8055b0ffb0ec1eb44e6531fc7a205f803404bfca36a7c9fce8945f2dR16-R23): Added the `noInjectCSS` option to the `Options` type, which allows users to disable automatic CSS injection and manually add the global CSS if desired.
* [`packages/studiocms_ui/src/index.ts`](diffhunk://#diff-238aaddf8055b0ffb0ec1eb44e6531fc7a205f803404bfca36a7c9fce8945f2dR109-R111): Updated the `integration` function to check the `noInjectCSS` option before injecting the global CSS script.

This is especially useful for StudioCMS where we don't want our dashboard styles leaking to the front-end or other packages.