### PR TITLE
Add viewBox attribute to IconBase component

### DIFF
--- a/.changeset/little-buttons-travel.md
+++ b/.changeset/little-buttons-travel.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Add viewbox attribute for IconBase component

--- a/packages/studiocms_ui/src/components/Icon/IconBase.astro
+++ b/packages/studiocms_ui/src/components/Icon/IconBase.astro
@@ -71,6 +71,8 @@ for (const attr in attributes) {
 	renderAttribsHTML += ` ${attr}="${attributes[attr]}"`;
 }
 
-const svg = `<svg style="min-width: ${attributes.height || 24}px" xmlns="http://www.w3.org/2000/svg"${renderAttribsHTML}>${body}</svg>`;
+const viewBox = renderData.attributes.viewBox;
+
+const svg = `<svg style="min-width: ${attributes.height || 24}px" xmlns="http://www.w3.org/2000/svg"${renderAttribsHTML}${viewBox && ` viewbox="${viewBox}"`}>${body}</svg>`;
 ---
 <Fragment set:html={svg} />


### PR DESCRIPTION
This pull request includes changes to the `@studiocms/ui` package to add a `viewBox` attribute to the `IconBase` component.

Improvements to `IconBase` component:

* [`.changeset/little-buttons-travel.md`](diffhunk://#diff-3cbc243e890f85e712cbda487c2a9095e38806937e2cc64aff0322380c8241c2R1-R5): Added a patch changeset for the `@studiocms/ui` package to document the addition of the `viewBox` attribute for the `IconBase` component.
* [`packages/studiocms_ui/src/components/Icon/IconBase.astro`](diffhunk://#diff-3672021a833e307406d55a766a78322c884e31a70d6e8df31c32853b97611e1eL74-R76): Modified the `svg` element creation to include the `viewBox` attribute if it is provided in the `renderData.attributes`.