### PR TITLE
Fix card footer being present even when empty

### DIFF
--- a/.changeset/silly-dogs-flash.md
+++ b/.changeset/silly-dogs-flash.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Fixes card footers to be hidden should they have no content

--- a/packages/studiocms_ui/src/components/Card/card.css
+++ b/packages/studiocms_ui/src/components/Card/card.css
@@ -35,6 +35,10 @@
 	padding: 1rem;
 }
 
+.sui-card-footer:not(:has(*)) {
+	display: none;
+}
+
 .filled .sui-card-footer {
 	border: none;
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes the footer of a `<Card />` component being present even when it was empty, causing a gap to be created that would look like additional padding at the bottom of the card in some cases.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->