### PR TITLE
Add Newsletter component and integrate it into the homepage of docs

### DIFF
--- a/.changeset/twenty-mangos-run.md
+++ b/.changeset/twenty-mangos-run.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+add value prop to checkbox

--- a/.changeset/twenty-mangos-run.md
+++ b/.changeset/twenty-mangos-run.md
@@ -2,4 +2,4 @@
 "@studiocms/ui": patch
 ---
 
-add value prop to checkbox
+Adds a value prop to the checkbox

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -35,7 +35,6 @@ import { toast } from "studiocms:ui/components";
         const response = await fetch(form.action, {
             method: form.method,
             body: formData,
-            mode: 'no-cors',
         });
 
         if (response.ok) {

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -3,18 +3,12 @@ import { Button, Checkbox, Icon, Input } from 'studiocms:ui/components';
 ---
 <form method="post" action="https://newsletter.studiocms.dev/subscription/form" id="newsletter-form">
     <div class="newsletter-container">
-        <h3>Get the latest updates from the StudioCMS Newsletter</h3>
+        <span>Subscribe to our newsletter</span>
         <input type="hidden" name="nonce" />
 
         <div class="newsletter-inputs">
-            <Input type="email" name="email" label="Email" isRequired placeholder='E-mail' />
-            <Input type="text" name="name" label="Name" placeholder='Name (optional)' />
-        </div>
-    
-        <div class="newsletter-button">
-            <Checkbox name="l" label="StudioCMS Newsletter" value="06711dc1-78ff-4993-9d79-df44ba3572fa" defaultChecked />
-            <Button type="submit" variant="outlined" color='primary' size={'sm'}>
-                <Icon name='newspaper-20-solid' slot="start-content" width={20} height={20} />
+            <Input type="email" name="email" isRequired placeholder='E-mail' aria-label='E-Mail' class='newsletter-email-input' />
+            <Button type="submit" color='primary' style="width: fit-content;">
                 Subscribe
             </Button>
         </div>
@@ -58,16 +52,17 @@ import { toast } from "studiocms:ui/components";
         display: flex;
         flex-direction: column;
         justify-content: center;
-        margin-top: 2rem;
         gap: .5rem;
 
         text-wrap: wrap;
     }
 
     .newsletter-inputs {
-        display: grid;
+        display: flex;
+        flex-direction: row;
         gap: .5rem;
-        grid-template-columns: 1fr 1fr;
+        align-items: center;
+        height: fit-content;
 
         @media (max-width: 768px) {
             grid-template-columns: 1fr;
@@ -82,4 +77,7 @@ import { toast } from "studiocms:ui/components";
         gap: .5rem;
     }
 
+    .newsletter-email-input {
+        height: 40px;
+    }
 </style>

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -35,6 +35,7 @@ import { toast } from "studiocms:ui/components";
         const response = await fetch(form.action, {
             method: form.method,
             body: formData,
+            mode: 'no-cors',
         });
 
         if (response.ok) {

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -1,9 +1,9 @@
 ---
-import { Button, Icon, Input } from 'studiocms:ui/components';
+import { Button, Checkbox, Icon, Input } from 'studiocms:ui/components';
 ---
 <form method="post" action="https://newsletter.studiocms.dev/subscription/form" id="newsletter-form">
     <div class="newsletter-container">
-        <h3>Get the latest Updates from the StudioCMS Newsletter</h3>
+        <h3>Get the latest updates from the StudioCMS Newsletter</h3>
         <input type="hidden" name="nonce" />
 
         <div class="newsletter-inputs">
@@ -12,8 +12,7 @@ import { Button, Icon, Input } from 'studiocms:ui/components';
         </div>
     
         <div class="newsletter-button">
-            <input id="06711" type="checkbox" name="l" checked value="06711dc1-78ff-4993-9d79-df44ba3572fa" />
-            <label for="06711">StudioCMS Newsletter</label>
+            <Checkbox name="l" label="StudioCMS Newsletter" value="06711dc1-78ff-4993-9d79-df44ba3572fa" defaultChecked />
             <Button type="submit" variant="outlined" color='primary' size={'sm'}>
                 <Icon name='newspaper-20-solid' slot="start-content" width={20} height={20} />
                 Subscribe

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -63,10 +63,7 @@ import { toast } from "studiocms:ui/components";
         gap: .5rem;
         align-items: center;
         height: fit-content;
-
-        @media (max-width: 768px) {
-            grid-template-columns: 1fr;
-        }
+        max-width: 400px;
     }
 
     .newsletter-button {

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -5,6 +5,7 @@ import { Button, Checkbox, Icon, Input } from 'studiocms:ui/components';
     <div class="newsletter-container">
         <span>Subscribe to our newsletter</span>
         <input type="hidden" name="nonce" />
+        <input id="06711" type="checkbox" name="l" hidden checked value="06711dc1-78ff-4993-9d79-df44ba3572fa" />
 
         <div class="newsletter-inputs">
             <Input type="email" name="email" isRequired placeholder='E-mail' aria-label='E-Mail' class='newsletter-email-input' />

--- a/docs/src/components/Newsletter.astro
+++ b/docs/src/components/Newsletter.astro
@@ -1,0 +1,86 @@
+---
+import { Button, Icon, Input } from 'studiocms:ui/components';
+---
+<form method="post" action="https://newsletter.studiocms.dev/subscription/form" id="newsletter-form">
+    <div class="newsletter-container">
+        <h3>Get the latest Updates from the StudioCMS Newsletter</h3>
+        <input type="hidden" name="nonce" />
+
+        <div class="newsletter-inputs">
+            <Input type="email" name="email" label="Email" isRequired placeholder='E-mail' />
+            <Input type="text" name="name" label="Name" placeholder='Name (optional)' />
+        </div>
+    
+        <div class="newsletter-button">
+            <input id="06711" type="checkbox" name="l" checked value="06711dc1-78ff-4993-9d79-df44ba3572fa" />
+            <label for="06711">StudioCMS Newsletter</label>
+            <Button type="submit" variant="outlined" color='primary' size={'sm'}>
+                <Icon name='newspaper-20-solid' slot="start-content" width={20} height={20} />
+                Subscribe
+            </Button>
+        </div>
+    </div>
+</form>
+
+<script>
+import { toast } from "studiocms:ui/components";
+
+    const form = document.getElementById('newsletter-form') as HTMLFormElement;
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const formData = new FormData(form);
+
+        const response = await fetch(form.action, {
+            method: form.method,
+            body: formData,
+        });
+
+        if (response.ok) {
+            form.reset();
+            toast({
+                title: 'Success',
+                type: 'success',
+                description: 'You have successfully subscribed to the StudioCMS Newsletter.',
+            })
+        } else {
+            toast({
+                title: 'Error',
+                type: 'danger',
+                description: 'An error occurred while subscribing to the StudioCMS Newsletter.',
+            })
+        }
+    });
+</script>
+
+<style>
+    .newsletter-container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin-top: 2rem;
+        gap: .5rem;
+
+        text-wrap: wrap;
+    }
+
+    .newsletter-inputs {
+        display: grid;
+        gap: .5rem;
+        grid-template-columns: 1fr 1fr;
+
+        @media (max-width: 768px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .newsletter-button {
+        display: flex;
+        flex-direction: row;
+        justify-content: end;
+        align-items: center;
+        gap: .5rem;
+    }
+
+</style>

--- a/docs/src/components/landing/EcosystemSection.astro
+++ b/docs/src/components/landing/EcosystemSection.astro
@@ -13,7 +13,7 @@ import SwordsIcon from '~/assets/swords.svg';
     <div class="ecosystem-benefits">
         <div class="benefit-card">
             <AstroLogo width={24} height={24} />
-            <h3>Astro-first</h3>
+            <h3>Astro-native</h3>
             <p>
                 The StudioCMS project is built for Astro with Astro and the community in mind. 
                 You can be sure that any of our projects will be focused on improving the 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -53,12 +53,16 @@ for (let i = 0; i < socialProofEntries.length; i += chunkSize) {
         copyright={'MIT License \u00A9 2024 - StudioCMS'}
     >
         <div slot="brand" class="footer-brand">
-            <LogoAdaptive height={48} width={45.76} />
-            <span class="studiocms-footer-text">
-                <span>StudioCMS</span>
-                <span>UI</span>
-            </span>
-            <Newsletter />
+            <div class="brand-newsletter">
+                <div class="brand-logo">
+                    <LogoAdaptive height={48} width={45.76} />
+                    <span class="studiocms-footer-text">
+                        <span>StudioCMS</span>
+                        <span>UI</span>
+                    </span>
+                </div>
+                <Newsletter />
+            </div>
         </div>
         <div slot="socials" class="socials">
             <a href="https://github.com/withstudiocms" aria-label="GitHub">
@@ -101,8 +105,8 @@ for (let i = 0; i < socialProofEntries.length; i += chunkSize) {
         .footer-brand {
             flex-direction: column;
             gap: 1rem;
+            width: 100%;
         }
-        
     }
 
     .studiocms-footer-text {
@@ -128,6 +132,13 @@ for (let i = 0; i < socialProofEntries.length; i += chunkSize) {
 
     .socials a:hover {
         color: hsl(var(--text-normal));
+    }
+
+    .brand-newsletter {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        width: 100%;
     }
 </style>
 <style is:global>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -2,7 +2,7 @@
 import '@fontsource-variable/onest/index.css';
 import '@fontsource-variable/fira-code/index.css';
 
-import { Button, Footer, Modal, Toaster } from 'studiocms:ui/components';
+import { Button, Divider, Footer, Modal, Toaster } from 'studiocms:ui/components';
 
 import { getCollection } from 'astro:content';
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
@@ -12,6 +12,7 @@ import GitHubLogo from '~/assets/github.svg';
 import LogoAdaptive from '~/assets/logo-adaptive.svg';
 import PatreonLogo from '~/assets/patreon.svg';
 import TwitterLogo from '~/assets/twitter.svg';
+import Newsletter from '~/components/Newsletter.astro';
 import EcosystemSection from '~/components/landing/EcosystemSection.astro';
 import HeroSection from '~/components/landing/HeroSection.astro';
 import ShowcaseSection from '~/components/landing/ShowcaseSection.astro';
@@ -57,6 +58,7 @@ for (let i = 0; i < socialProofEntries.length; i += chunkSize) {
                 <span>StudioCMS</span>
                 <span>UI</span>
             </span>
+            <Newsletter />
         </div>
         <div slot="socials" class="socials">
             <a href="https://github.com/withstudiocms" aria-label="GitHub">
@@ -93,6 +95,14 @@ for (let i = 0; i < socialProofEntries.length; i += chunkSize) {
         gap: 1.5rem;
         align-items: center;
         white-space: nowrap;
+    }
+
+    @media screen and (max-width: 768px) {
+        .footer-brand {
+            flex-direction: column;
+            gap: 1rem;
+        }
+        
     }
 
     .studiocms-footer-text {

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -2,7 +2,7 @@
 import '@fontsource-variable/onest/index.css';
 import '@fontsource-variable/fira-code/index.css';
 
-import { Button, Divider, Footer, Modal, Toaster } from 'studiocms:ui/components';
+import { Footer, Modal, Toaster } from 'studiocms:ui/components';
 
 import { getCollection } from 'astro:content';
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -140,6 +140,13 @@ for (let i = 0; i < socialProofEntries.length; i += chunkSize) {
         gap: 1rem;
         width: 100%;
     }
+
+    .brand-logo {
+        display: flex;
+        flex-direction: row;
+        gap: 1rem;
+        align-items: center;
+    }
 </style>
 <style is:global>
     .showcase header {

--- a/packages/studiocms_ui/src/components/Checkbox/Checkbox.astro
+++ b/packages/studiocms_ui/src/components/Checkbox/Checkbox.astro
@@ -36,6 +36,10 @@ interface Props {
 	 * Whether the checkbox is required.
 	 */
 	isRequired?: boolean;
+	/**
+	 * The value of the checkbox.
+	 */
+	value?: string;
 }
 
 const {
@@ -46,6 +50,7 @@ const {
 	name = generateID('checkbox'),
 	label,
 	isRequired,
+	value,
 } = Astro.props;
 
 const iconSizes = {
@@ -83,6 +88,7 @@ const iconSizes = {
       disabled={disabled}
       required={isRequired}
       class="sui-checkbox"
+	  value={value}
       hidden
     />
   </div>


### PR DESCRIPTION
This pull request introduces a new newsletter subscription form and makes some adjustments to the main page to incorporate this feature. The most important changes are the addition of the `Newsletter` component and the corresponding styles and scripts to handle form submission and user feedback.

### Addition of Newsletter Subscription Form:

* [`docs/src/components/Newsletter.astro`](diffhunk://#diff-db94e67c3f3d3740bba569f5b17767db24d157327c872a6e44296e297aebec9eR1-R86): Added a new `Newsletter` component with a form for users to subscribe to the StudioCMS newsletter. This includes form elements, a submit handler, and styling.

### Integration of Newsletter Component:

* [`docs/src/pages/index.astro`](diffhunk://#diff-c7ed1fae6e40bd1e7ece8c4677f63529f7a5230ca3a5636c5e096f493e0da13aL5-R5): Imported the `Newsletter` component and included it in the main page layout. Removed an unused `Button` import. [[1]](diffhunk://#diff-c7ed1fae6e40bd1e7ece8c4677f63529f7a5230ca3a5636c5e096f493e0da13aL5-R5) [[2]](diffhunk://#diff-c7ed1fae6e40bd1e7ece8c4677f63529f7a5230ca3a5636c5e096f493e0da13aR15) [[3]](diffhunk://#diff-c7ed1fae6e40bd1e7ece8c4677f63529f7a5230ca3a5636c5e096f493e0da13aR61)

### Responsive Design Adjustments:

* [`docs/src/pages/index.astro`](diffhunk://#diff-c7ed1fae6e40bd1e7ece8c4677f63529f7a5230ca3a5636c5e096f493e0da13aR100-R107): Added media queries to adjust the layout of the footer brand section for smaller screens.