### PR TITLE
Fix z-index for starlight tabs line

### DIFF
--- a/.changeset/fuzzy-tables-attack.md
+++ b/.changeset/fuzzy-tables-attack.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Fixes a z-index for starlight variant tabs being too great

--- a/packages/studiocms_ui/src/components/Tabs/tabs.css
+++ b/packages/studiocms_ui/src/components/Tabs/tabs.css
@@ -121,7 +121,7 @@
 	position: absolute;
 	bottom: 0;
 	left: 0;
-	z-index: 15;
+	z-index: 1;
 }
 
 .sui-tabs-container.starlight .sui-tab-header:focus-visible::after {


### PR DESCRIPTION
#### Description

- Fixed a z-index value for tabs that would sometimes make an element show up above navbars and other elements

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->