### PR TITLE
Fix double sidebar CSS

### DIFF
--- a/.changeset/long-melons-cry.md
+++ b/.changeset/long-melons-cry.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Fixes mismatched IDs in the CSS for the double sidebar component

--- a/packages/studiocms_ui/src/components/Sidebar/Double.astro
+++ b/packages/studiocms_ui/src/components/Sidebar/Double.astro
@@ -60,10 +60,6 @@
       --sidebars-container-width: calc(280px + 1px);
     }
 
-    #swap-to-inner {
-      display: block;
-    }
-
     #sui-sidebars.inner {
       #sui-sidebar-outer,
       #sui-sidebar-inner {

--- a/packages/studiocms_ui/src/components/Sidebar/Double.astro
+++ b/packages/studiocms_ui/src/components/Sidebar/Double.astro
@@ -65,8 +65,8 @@
     }
 
     #sui-sidebars.inner {
-      #sidebar-outer,
-      #sidebar-inner {
+      #sui-sidebar-outer,
+      #sui-sidebar-inner {
         transform: translateX(-100%);
       }
     }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes some CSS for the double navbar that made switching between the layers on mobile impossible

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->