### PR TITLE
add: base for flexible tooltips

### DIFF
--- a/.changeset/nice-ants-visit.md
+++ b/.changeset/nice-ants-visit.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+adds the tooltip component

--- a/docs/src/content/docs/docs/components/tooltip.mdx
+++ b/docs/src/content/docs/docs/components/tooltip.mdx
@@ -120,10 +120,6 @@ The `defaultOpen` prop can only be used on one tooltip at a time per page. If yo
         <button>Open by default</button>
         <Fragment slot="tooltip">This tooltip is open by default.</Fragment>
       </Tooltip>
-      <Tooltip>
-        <button>Closed by default</button>
-        <Fragment slot="tooltip">This tooltip is closed by default.</Fragment>
-      </Tooltip>
     </PreviewCard>
   </TabItem>
   <TabItem label="Code">
@@ -135,10 +131,6 @@ The `defaultOpen` prop can only be used on one tooltip at a time per page. If yo
     <Tooltip defaultOpen={true}>
       <button>Open by default</button>
       <Fragment slot="tooltip">This tooltip is open by default.</Fragment>
-    </Tooltip>
-    <Tooltip>
-      <button>Closed by default</button>
-      <Fragment slot="tooltip">This tooltip is closed by default.</Fragment>
     </Tooltip>
     ```
   </TabItem>
@@ -255,10 +247,6 @@ The tooltip can be styled with different variants. The default is `default`. The
     ```
   </TabItem>
 </Tabs>
-
-### Inline
-
-TODO
 
 ### Gap
 

--- a/docs/src/content/docs/docs/components/tooltip.mdx
+++ b/docs/src/content/docs/docs/components/tooltip.mdx
@@ -13,6 +13,10 @@ import { Tooltip } from "studiocms:ui/components";
 
 A tooltip component that will show on hover (desktop) or tap (mobile). It's used to provide additional information about an element.
 
+:::note[Note]
+Only one tooltip can be open at a time. If you open another tooltip, the previous one will close.
+:::
+
 ## Usage
 
 <Tabs>
@@ -109,6 +113,8 @@ The values for the position prop are:
 
 The tooltip can be set to be open by default. This is useful for debugging or when you want the tooltip to be visible without user interaction.
 
+Keep in mind, if a user interacts with another tooltip, the `defaultOpen` tooltip will close, even if it was not in view.
+
 :::note[Note]
 The `defaultOpen` prop can only be used on one tooltip at a time per page. If you set it on multiple tooltips, only the last one will be open by default.
 :::
@@ -174,6 +180,10 @@ The tooltip can be styled with different colors. The default is `default`. The a
         <button>Info</button>
         <Fragment slot="tooltip">This is an info tooltip.</Fragment>
       </Tooltip>
+      <Tooltip color="mono">
+        <button>Monochrome</button>
+        <Fragment slot="tooltip">This is an monochrome tooltip.</Fragment>
+      </Tooltip>
     </PreviewCard>
   </TabItem>
   <TabItem label="Code">
@@ -205,6 +215,10 @@ The tooltip can be styled with different colors. The default is `default`. The a
     <Tooltip color='info'>
       <button>Info</button>
       <Fragment slot="tooltip">This is an info tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip color="mono">
+      <button>Monochrome</button>
+      <Fragment slot="tooltip">This is an monochrome tooltip.</Fragment>
     </Tooltip>
     ```
   </TabItem>

--- a/docs/src/content/docs/docs/components/tooltip.mdx
+++ b/docs/src/content/docs/docs/components/tooltip.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 import PreviewCard from "~/components/PreviewCard.astro";
-import { Tooltip } from 'studiocms:ui/components';
+import { Tooltip } from "studiocms:ui/components";
 
 A tooltip component that will show on hover (desktop) or tap (mobile). It's used to provide additional information about an element.
 
@@ -18,16 +18,14 @@ A tooltip component that will show on hover (desktop) or tap (mobile). It's used
 <Tabs>
   <TabItem label="Preview">
     <PreviewCard>
-      <p>
-        Lorem ipsum dolor sit{' '}
-        <Tooltip inline={true}>
-          <span>amet</span>
-          <Fragment slot="tooltip">
-            <p>This contains the tooltip information that will be shown.</p>
-          </Fragment>
-        </Tooltip>
-        {' '}, consectetur adipiscing elit.
-      </p>
+      <Tooltip>
+        <button tabindex="0">
+          Hover or tap me
+        </button>
+        <Fragment slot="tooltip">
+          <p>This contains the tooltip information that will be shown.</p>
+        </Fragment>
+      </Tooltip>
     </PreviewCard>
   </TabItem>
   <TabItem label="Code">
@@ -36,16 +34,216 @@ A tooltip component that will show on hover (desktop) or tap (mobile). It's used
     import { Tooltip } from 'studiocms:ui/components';
     ---
 
-    <p>
-      Lorem ipsum dolor sit{' '}
-      <Tooltip inline={true}>
-        <span>amet</span>
-        <Fragment slot="tooltip">
-          <p>This contains the tooltip information that will be shown.</p>
-        </Fragment>
+    <Tooltip>
+      <button>
+        Hover or tap me
+      </button>
+      <Fragment slot="tooltip">
+        <p>This contains the tooltip information that will be shown.</p>
+      </Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+### Position
+
+The tooltip can be positioned in various ways in relation to the anchor element. The default is `auto`.
+
+The values for the position prop are:
+
+- `auto`: The tooltip will resort to the positions in this order: 'top', 'bottom', 'right', 'left'.
+- `top`: The tooltip will be positioned *above* the anchor element, otherwise fall back on this order: 'bottom', 'right', 'left'.
+- `bottom`: The tooltip will be positioned *below* the anchor element, otherwise fall back on this order: 'top', 'right', 'left'.
+- `left`: The tooltip will be positioned to the *left* of the anchor element, otherwise fall back on this order: 'right', 'top', 'bottom'.
+- `right`: The tooltip will be positioned to the *right* of the anchor element, otherwise fall back on this order: 'left', 'top', 'bottom'.
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip position="top">
+        <button>Top</button>
+        <Fragment slot="tooltip">This is a tooltip on top.</Fragment>
       </Tooltip>
-      {' '}, consectetur adipiscing elit.
-    </p>
+      <Tooltip position="bottom">
+        <button>Bottom</button>
+        <Fragment slot="tooltip">This is a tooltip on bottom.</Fragment>
+      </Tooltip>
+      <Tooltip position="left">
+        <button>Left</button>
+        <Fragment slot="tooltip">This is a tooltip on left.</Fragment>
+      </Tooltip>
+      <Tooltip position="right">
+        <button>Right</button>
+        <Fragment slot="tooltip">This is a tooltip on right.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipPositionExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip position='top'>
+      <button>Top</button>
+      <Fragment slot="tooltip">This is a tooltip on top.</Fragment>
+    </Tooltip>
+    <Tooltip position='bottom'>
+      <button>Bottom</button>
+      <Fragment slot="tooltip">This is a tooltip on bottom.</Fragment>
+    </Tooltip>
+    <Tooltip position='left'>
+      <button>Left</button>
+      <Fragment slot="tooltip">This is a tooltip on left.</Fragment>
+    </Tooltip>
+    <Tooltip position='right'>
+      <button>Right</button>
+      <Fragment slot="tooltip">This is a tooltip on right.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+
+### Inline
+
+TODO
+
+### Delays
+
+The tooltip can be configured to have delays for showing and hiding. The default is 0ms for showing and 0ms for hiding.
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip enterDelay={500} exitDelay={0}>
+        <button>Enter Delay: 500ms</button>
+        <Fragment slot="tooltip">This tooltip has a 500ms enter delay.</Fragment>
+      </Tooltip>
+      <Tooltip enterDelay={0} exitDelay={500}>
+        <button>Exit Delay: 500ms</button>
+        <Fragment slot="tooltip">This tooltip has a 500ms exit delay.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipDelaysExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip enterDelay={500} exitDelay={0}>
+      <button>Enter Delay: 500ms</button>
+      <Fragment slot="tooltip">This tooltip has a 500ms enter delay.</Fragment>
+    </Tooltip>
+    <Tooltip enterDelay={0} exitDelay={500}>
+      <button>Exit Delay: 500ms</button>
+      <Fragment slot="tooltip">This tooltip has a 500ms exit delay.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+### Hover Activation Only
+
+By default, the tooltip will show on hover or tap. You can disable the tap activation by setting the `hoverOnly` prop to `true`.
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip hoverOnly>
+        <button>Hover Only</button>
+        <Fragment slot="tooltip">This tooltip will only show on hover.</Fragment>
+      </Tooltip>
+      <Tooltip>
+        <button>Hover or Tap</button>
+        <Fragment slot="tooltip">This tooltip will show on hover or tap.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipHoverOnlyExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip hoverOnly>
+      <button>Hover Only</button>
+      <Fragment slot="tooltip">This tooltip will only show on hover.</Fragment>
+    </Tooltip>
+    <Tooltip>
+      <button>Hover or Tap</button>
+      <Fragment slot="tooltip">This tooltip will show on hover or tap.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+### Animation
+
+By default, the tooltip will fade in when shown and out when hidden. You can disable this by setting the `animate` prop to `false`.
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip animate={false}>
+        <button>Animate: false</button>
+        <Fragment slot="tooltip">This tooltip will not animate.</Fragment>
+      </Tooltip>
+      <Tooltip>
+        <button>Animate: true</button>
+        <Fragment slot="tooltip">This tooltip will animate.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipAnimateExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip animate={false}>
+      <button>Animate: false</button>
+      <Fragment slot="tooltip">This tooltip will not animate.</Fragment>
+    </Tooltip>
+    <Tooltip>
+      <button>Animate: true</button>
+      <Fragment slot="tooltip">This tooltip will animate.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+### Pointer
+
+By default, the tooltip will show a pointer to indicate where the tooltip is pointing. You can disable this by setting the `pointer` prop to `false`.
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip pointer={false}>
+        <button>Pointer: false</button>
+        <Fragment slot="tooltip">This tooltip will not show a pointer.</Fragment>
+      </Tooltip>
+      <Tooltip>
+        <button>Pointer: true</button>
+        <Fragment slot="tooltip">This tooltip will show a pointer.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipPointerExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip pointer={false}>
+      <button>Pointer: false</button>
+      <Fragment slot="tooltip">This tooltip will not show a pointer.</Fragment>
+    </Tooltip>
+    <Tooltip>
+      <button>Pointer: true</button>
+      <Fragment slot="tooltip">This tooltip will show a pointer.</Fragment>
+    </Tooltip>
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/docs/components/tooltip.mdx
+++ b/docs/src/content/docs/docs/components/tooltip.mdx
@@ -1,0 +1,51 @@
+---
+i18nReady: false
+title: Tooltip
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import PreviewCard from "~/components/PreviewCard.astro";
+import { Tooltip } from 'studiocms:ui/components';
+
+A tooltip component that will show on hover (desktop) or tap (mobile). It's used to provide additional information about an element.
+
+## Usage
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <p>
+        Lorem ipsum dolor sit{' '}
+        <Tooltip inline={true}>
+          <span>amet</span>
+          <Fragment slot="tooltip">
+            <p>This contains the tooltip information that will be shown.</p>
+          </Fragment>
+        </Tooltip>
+        {' '}, consectetur adipiscing elit.
+      </p>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <p>
+      Lorem ipsum dolor sit{' '}
+      <Tooltip inline={true}>
+        <span>amet</span>
+        <Fragment slot="tooltip">
+          <p>This contains the tooltip information that will be shown.</p>
+        </Fragment>
+      </Tooltip>
+      {' '}, consectetur adipiscing elit.
+    </p>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/docs/components/tooltip.mdx
+++ b/docs/src/content/docs/docs/components/tooltip.mdx
@@ -105,10 +105,197 @@ The values for the position prop are:
   </TabItem>
 </Tabs>
 
+### Default State
+
+The tooltip can be set to be open by default. This is useful for debugging or when you want the tooltip to be visible without user interaction.
+
+:::note[Note]
+The `defaultOpen` prop can only be used on one tooltip at a time per page. If you set it on multiple tooltips, only the last one will be open by default.
+:::
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip defaultOpen={true}>
+        <button>Open by default</button>
+        <Fragment slot="tooltip">This tooltip is open by default.</Fragment>
+      </Tooltip>
+      <Tooltip>
+        <button>Closed by default</button>
+        <Fragment slot="tooltip">This tooltip is closed by default.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipDefaultStateExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip defaultOpen={true}>
+      <button>Open by default</button>
+      <Fragment slot="tooltip">This tooltip is open by default.</Fragment>
+    </Tooltip>
+    <Tooltip>
+      <button>Closed by default</button>
+      <Fragment slot="tooltip">This tooltip is closed by default.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+### Colors
+
+The tooltip can be styled with different colors. The default is `default`. The available colors are:
+
+- `default`
+- `primary`
+- `success`
+- `warning`
+- `danger`
+- `info`
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip color="default">
+        <button>Default</button>
+        <Fragment slot="tooltip">This is a default tooltip.</Fragment>
+      </Tooltip>
+      <Tooltip color="primary">
+        <button>Primary</button>
+        <Fragment slot="tooltip">This is a primary tooltip.</Fragment>
+      </Tooltip>
+      <Tooltip color="success">
+        <button>Success</button>
+        <Fragment slot="tooltip">This is a success tooltip.</Fragment>
+      </Tooltip>
+      <Tooltip color="warning">
+        <button>Warning</button>
+        <Fragment slot="tooltip">This is a warning tooltip.</Fragment>
+      </Tooltip>
+      <Tooltip color="danger">
+        <button>Danger</button>
+        <Fragment slot="tooltip">This is a danger tooltip.</Fragment>
+      </Tooltip>
+      <Tooltip color="info">
+        <button>Info</button>
+        <Fragment slot="tooltip">This is an info tooltip.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipColorsExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip color='default'>
+      <button>Default</button>
+      <Fragment slot="tooltip">This is a default tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip color='primary'>
+      <button>Primary</button>
+      <Fragment slot="tooltip">This is a primary tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip color='success'>
+      <button>Success</button>
+      <Fragment slot="tooltip">This is a success tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip color='warning'>
+      <button>Warning</button>
+      <Fragment slot="tooltip">This is a warning tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip color='danger'>
+      <button>Danger</button>
+      <Fragment slot="tooltip">This is a danger tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip color='info'>
+      <button>Info</button>
+      <Fragment slot="tooltip">This is an info tooltip.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
+
+### Variants
+
+The tooltip can be styled with different variants. The default is `default`. The available variants are:
+
+- `default`
+- `outlined`
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip variant="default">
+        <button>Default</button>
+        <Fragment slot="tooltip">This is a default tooltip.</Fragment>
+      </Tooltip>
+      <Tooltip variant="outlined">
+        <button>Outlined</button>
+        <Fragment slot="tooltip">This is an outlined tooltip.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipVariantsExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip variant='default'>
+      <button>Default</button>
+      <Fragment slot="tooltip">This is a default tooltip.</Fragment>
+    </Tooltip>
+    <Tooltip variant='outlined'>
+      <button>Outlined</button>
+      <Fragment slot="tooltip">This is an outlined tooltip.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
 
 ### Inline
 
 TODO
+
+### Gap
+
+The tooltip can be configured to have a gap between the anchor element and the tooltip. The default is 8px.
+
+(Yes, this works with negative values too!)
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Tooltip gap={24}>
+        <button>Gap: 24px</button>
+        <Fragment slot="tooltip">This tooltip has a 24px gap.</Fragment>
+      </Tooltip>
+      <Tooltip>
+        <button>Default Gap</button>
+        <Fragment slot="tooltip">This tooltip has the default 8px gap.</Fragment>
+      </Tooltip>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro showLinenumbers title="TooltipGapExample.astro"
+    ---
+    import { Tooltip } from 'studiocms:ui/components';
+    ---
+
+    <Tooltip gap={24}>
+      <button>Gap: 24px</button>
+      <Fragment slot="tooltip">This tooltip has a 24px gap.</Fragment>
+    </Tooltip>
+    <Tooltip>
+      <button>Default Gap</button>
+      <Fragment slot="tooltip">This tooltip has the default 8px gap.</Fragment>
+    </Tooltip>
+    ```
+  </TabItem>
+</Tabs>
 
 ### Delays
 
@@ -247,3 +434,11 @@ By default, the tooltip will show a pointer to indicate where the tooltip is poi
     ```
   </TabItem>
 </Tabs>
+
+### Programmatic Control
+
+You can control the tooltip programmatically by accessing the `sui.tooltips` object on the window. The following methods are available:
+
+- `sui.tooltips.get(tooltipId: string)`: Get the tooltip instance by its ID, if it exists.
+- `sui.tooltips.show(tooltipId: string)`: Opens the tooltip with the given ID, if it exists.
+- `sui.tooltips.hide(tooltipId: string)`: Closes the tooltip with the given ID.

--- a/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
+++ b/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
@@ -1,5 +1,5 @@
 ---
-import './tooltip.css';
+import "./tooltip.css";
 
 interface Props {
   /**
@@ -7,7 +7,7 @@ interface Props {
    *
    * 'auto' will try to position below, then above, then right, then left.
    */
-  position?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
+  position?: "auto" | "top" | "bottom" | "left" | "right";
 
   /**
    * Whether the tooltip should be inline with the anchor element. Defaults to false.
@@ -51,29 +51,37 @@ const {
   animate = true,
   pointer = true,
 } = Astro.props;
+
+const Tag = inline ? "span" : "div";
 ---
 
-<div class:list={["sui-tooltip-container", inline && "inline"]} data-sui-tooltip data-sui-tooltip-options={JSON.stringify({
-  position,
-  enterDelay,
-  exitDelay,
-  hoverOnly,
-  animate,
-  pointer,
-})}>
-  <div class="sui-tooltip-anchor-wrapper" data-sui-tooltip-anchor>
+<Tag
+  class:list={["sui-tooltip-container", inline && "inline"]}
+  data-sui-tooltip
+  data-sui-tooltip-options={JSON.stringify({
+    position,
+    enterDelay,
+    exitDelay,
+    hoverOnly,
+    animate,
+    pointer,
+  })}
+>
+  <Tag class="sui-tooltip-anchor-wrapper" data-sui-tooltip-anchor>
     <slot />
-  </div>
-  <div class:list={["sui-tooltip-popup", animate && "animate"]} data-sui-tooltip-popup>
-    {pointer && (
-      <div class="sui-tooltip-pointer"></div>
-    )}
+  </Tag>
+  <div
+    class:list={["sui-tooltip-popup", animate && "animate"]}
+    data-sui-tooltip-popup
+    role="tooltip"
+  >
+    {pointer && <div class="sui-tooltip-pointer" />}
     <slot name="tooltip">
       <p>Warning: slot 'tooltip' was not found</p>
     </slot>
   </div>
-</div>
+</Tag>
 
 <script>
-import "studiocms:ui/scripts/tooltip";
+  import "studiocms:ui/scripts/tooltip";
 </script>

--- a/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
+++ b/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
@@ -1,0 +1,79 @@
+---
+import './tooltip.css';
+
+interface Props {
+  /**
+   * The position of the tooltip. Defaults to 'auto'.
+   *
+   * 'auto' will try to position below, then above, then right, then left.
+   */
+  position?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
+
+  /**
+   * Whether the tooltip should be inline with the anchor element. Defaults to false.
+   */
+  inline?: boolean;
+
+  /**
+   * The delay before the tooltip appears in milliseconds. Defaults to 0.
+   */
+  enterDelay?: number;
+
+  /**
+   * The delay before the tooltip disappears in milliseconds. Defaults to 0.
+   */
+  exitDelay: number;
+
+  /**
+   * Whether the tooltip should be hover only. Defaults to false.
+   *
+   * By default, the tooltip will show on mouse hover and click (for mobile support).
+   */
+  hoverOnly?: boolean;
+
+  /**
+   * Whether the tooltip should animate a fade in and out. Defaults to true.
+   */
+  animate?: boolean;
+
+  /**
+   * Render a triangle pointer on the tooltip. Defaults to true.
+   */
+  pointer?: boolean;
+}
+
+const {
+  position = "auto",
+  inline = false,
+  enterDelay = 0,
+  exitDelay = 0,
+  hoverOnly = false,
+  animate = true,
+  pointer = true,
+} = Astro.props;
+---
+
+<div class:list={["sui-tooltip-container", inline && "inline"]} data-sui-tooltip data-sui-tooltip-options={JSON.stringify({
+  position,
+  enterDelay,
+  exitDelay,
+  hoverOnly,
+  animate,
+  pointer,
+})}>
+  <div class="sui-tooltip-anchor-wrapper" data-sui-tooltip-anchor>
+    <slot />
+  </div>
+  <div class:list={["sui-tooltip-popup", animate && "animate"]} data-sui-tooltip-popup>
+    {pointer && (
+      <div class="sui-tooltip-pointer"></div>
+    )}
+    <slot name="tooltip">
+      <p>Warning: slot 'tooltip' was not found</p>
+    </slot>
+  </div>
+</div>
+
+<script>
+import "studiocms:ui/scripts/tooltip";
+</script>

--- a/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
+++ b/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
@@ -17,6 +17,10 @@ interface Props extends Omit<HTMLAttributes<"div">, "class:list"> {
 
   /**
    * Whether the tooltip should be inline with the anchor element. Defaults to false.
+   * 
+   * @todo This is not fully working, due to an Astro bug: https://github.com/withastro/astro/issues/13970
+   * 
+   * USE AT YOUR OWN RISK!
    */
   inline?: boolean;
 
@@ -43,7 +47,7 @@ interface Props extends Omit<HTMLAttributes<"div">, "class:list"> {
   /**
    * The delay before the tooltip disappears in milliseconds. Defaults to 0.
    */
-  exitDelay: number;
+  exitDelay?: number;
 
   /**
    * Whether the tooltip should be hover only. Defaults to false.
@@ -77,11 +81,9 @@ const {
   pointer = true,
   ...others
 } = Astro.props;
-
-const Tag = inline ? "span" : "div";
 ---
 
-<Tag
+<div
   class:list={["sui-tooltip-container", inline && "inline"]}
   data-sui-tooltip
   data-sui-tooltip-options={JSON.stringify({
@@ -96,9 +98,9 @@ const Tag = inline ? "span" : "div";
   })}
   {...others}
 >
-  <Tag class="sui-tooltip-anchor-wrapper" data-sui-tooltip-anchor>
+  <div class="sui-tooltip-anchor-wrapper" data-sui-tooltip-anchor>
     <slot />
-  </Tag>
+  </div>
   <div
     class={`sui-tooltip-popup color-${color} variant-${variant}`}
     class:list={[animate && "animate"]}
@@ -110,7 +112,7 @@ const Tag = inline ? "span" : "div";
       <p>Warning: slot 'tooltip' was not found</p>
     </slot>
   </div>
-</Tag>
+</div>
 
 <script>
   import "studiocms:ui/scripts/tooltip";

--- a/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
+++ b/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
@@ -1,7 +1,8 @@
 ---
 import "./tooltip.css";
+import type { HTMLAttributes } from "astro/types";
 
-interface Props {
+interface Props extends Omit<HTMLAttributes<"div">, "class:list"> {
   /**
    * The position of the tooltip. Defaults to 'auto'.
    *
@@ -10,9 +11,29 @@ interface Props {
   position?: "auto" | "top" | "bottom" | "left" | "right";
 
   /**
+   * Whether the tooltip should be opened by default. Defaults to false.
+   */
+  defaultOpen?: boolean;
+
+  /**
    * Whether the tooltip should be inline with the anchor element. Defaults to false.
    */
   inline?: boolean;
+
+  /**
+   * The variant of the tooltip. Defaults to 'default'.
+   */
+  variant?: "default" | "outlined";
+
+  /**
+   * The color of the tooltip. Defaults to 'default'.
+   */
+  color?: "default" | "primary" | "secondary" | "success" | "warning" | "error";
+
+  /**
+   * The gap between the tooltip and the anchor element in pixels. Defaults to 8.
+   */
+  gap?: number;
 
   /**
    * The delay before the tooltip appears in milliseconds. Defaults to 0.
@@ -44,12 +65,17 @@ interface Props {
 
 const {
   position = "auto",
+  defaultOpen = false,
   inline = false,
+  variant = "default",
+  color = "default",
+  gap = 8,
   enterDelay = 0,
   exitDelay = 0,
   hoverOnly = false,
   animate = true,
   pointer = true,
+  ...others
 } = Astro.props;
 
 const Tag = inline ? "span" : "div";
@@ -60,18 +86,22 @@ const Tag = inline ? "span" : "div";
   data-sui-tooltip
   data-sui-tooltip-options={JSON.stringify({
     position,
+    defaultOpen,
+    gap,
     enterDelay,
     exitDelay,
     hoverOnly,
     animate,
     pointer,
   })}
+  {...others}
 >
   <Tag class="sui-tooltip-anchor-wrapper" data-sui-tooltip-anchor>
     <slot />
   </Tag>
   <div
-    class:list={["sui-tooltip-popup", animate && "animate"]}
+    class={`sui-tooltip-popup color-${color} variant-${variant}`}
+    class:list={[animate && "animate"]}
     data-sui-tooltip-popup
     role="tooltip"
   >

--- a/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
+++ b/packages/studiocms_ui/src/components/Tooltip/Tooltip.astro
@@ -32,7 +32,7 @@ interface Props extends Omit<HTMLAttributes<"div">, "class:list"> {
   /**
    * The color of the tooltip. Defaults to 'default'.
    */
-  color?: "default" | "primary" | "secondary" | "success" | "warning" | "error";
+  color?: "default" | "primary" | "secondary" | "success" | "warning" | "error" | "mono";
 
   /**
    * The gap between the tooltip and the anchor element in pixels. Defaults to 8.

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.css
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.css
@@ -1,0 +1,60 @@
+.sui-tooltip-container {
+  display: block;
+  &.inline {
+    display: inline-block;
+  }
+}
+.sui-tooltip-popup {
+  position: absolute;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  border: solid 2px var(--border);
+  background-color: var(--background-step-3);
+  color: var(--text-dimmed);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+  min-width: 250px;
+  &[data-visible="true"] {
+    opacity: 1;
+    visibility: visible;
+  }
+  &.animate {
+    transition: opacity 0.2s ease-out, visibility 0.2s;
+  }
+}
+.sui-tooltip-pointer {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  z-index: 999;
+  background-color: var(--background-step-3);
+  border: solid 2px var(--border);
+}
+.sui-tooltip-position--top .sui-tooltip-pointer {
+  bottom: -9px;
+  transform: rotateZ(45deg);
+  border-left: none;
+  border-top: none;
+}
+.sui-tooltip-position--bottom .sui-tooltip-pointer {
+  top: -9px;
+  transform: rotateZ(45deg);
+  border-bottom: none;
+  border-right: none;
+}
+.sui-tooltip-position--left .sui-tooltip-pointer {
+  right: -9px;
+  transform: rotateZ(45deg);
+  border-bottom: none;
+  border-left: none;
+}
+.sui-tooltip-position--right .sui-tooltip-pointer {
+  left: -9px;
+  transform: rotateZ(45deg);
+  border-top: none;
+  border-right: none;
+}

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.css
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.css
@@ -57,6 +57,11 @@
   color: var(--text-light);
   border-color: var(--info-hover);
 }
+.sui-tooltip-popup.color-mono {
+  background-color: var(--mono-base);
+  color: var(--text-inverted);
+  border-color: var(--mono-hover);
+}
 .sui-tooltip-popup.color-default.variant-outlined {
   border-color: var(--text-muted);
   background-color: var(--default-base);
@@ -79,6 +84,10 @@
 }
 .sui-tooltip-popup.color-info.variant-outlined {
   border-color: var(--info-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-mono.variant-outlined {
+  border-color: var(--mono-hover);
   background-color: var(--default-base);
 }
 .sui-tooltip-popup.animate {
@@ -122,6 +131,10 @@
   background-color: var(--info-base);
   border-color: var(--info-hover);
 }
+.sui-tooltip-popup.color-mono .sui-tooltip-pointer {
+  background-color: var(--mono-base);
+  border-color: var(--mono-hover);
+}
 .sui-tooltip-popup.color-default.variant-outlined .sui-tooltip-pointer {
   border-color: var(--text-muted);
   background-color: var(--default-base);
@@ -143,6 +156,10 @@
 }
 .sui-tooltip-popup.color-info.variant-outlined .sui-tooltip-pointer {
   border-color: var(--info-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-mono.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--mono-hover);
   background-color: var(--default-base);
 }
 .sui-tooltip-popup.top .sui-tooltip-pointer {

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.css
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.css
@@ -4,7 +4,6 @@
 .sui-tooltip-container.inline {
   display: inline-block;
 }
-
 .sui-tooltip-popup {
   position: absolute;
   z-index: 1000;
@@ -35,27 +34,27 @@
 }
 .sui-tooltip-popup.color-primary {
   background-color: var(--primary-base);
-  color: var(--text-normal);
+  color: var(--text-inverted);
   border-color: var(--primary-hover);
 }
 .sui-tooltip-popup.color-success {
   background-color: var(--success-base);
-  color: var(--text-normal);
+  color: var(--text-dark);
   border-color: var(--success-hover);
 }
 .sui-tooltip-popup.color-warning {
   background-color: var(--warning-base);
-  color: var(--text-normal);
+  color: var(--text-dark);
   border-color: var(--warning-hover);
 }
 .sui-tooltip-popup.color-danger {
   background-color: var(--danger-base);
-  color: var(--text-normal);
+  color: var(--text-light);
   border-color: var(--danger-hover);
 }
 .sui-tooltip-popup.color-info {
   background-color: var(--info-base);
-  color: var(--text-normal);
+  color: var(--text-light);
   border-color: var(--info-hover);
 }
 .sui-tooltip-popup.color-default.variant-outlined {

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.css
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.css
@@ -1,9 +1,10 @@
 .sui-tooltip-container {
   display: block;
-  &.inline {
-    display: inline-block;
-  }
 }
+.sui-tooltip-container.inline {
+  display: inline-block;
+}
+
 .sui-tooltip-popup {
   position: absolute;
   z-index: 1000;
@@ -12,49 +13,158 @@
   justify-content: center;
   opacity: 0;
   visibility: hidden;
-  border: solid 2px var(--border);
-  background-color: var(--background-step-3);
-  color: var(--text-dimmed);
   border-radius: var(--radius-md);
-  padding: 0.5rem;
+  padding: 0.5rem 1rem;
   min-width: 250px;
   pointer-events: none;
-  &[data-visible="true"] {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: all;
-  }
-  &.animate {
-    transition: opacity 0.2s ease-out, visibility 0.2s;
-  }
 }
+.sui-tooltip-popup[data-visible="true"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: all;
+}
+.sui-tooltip-popup.variant-default,
+.sui-tooltip-popup.variant-outlined {
+  border-style: solid;
+  border-width: 1px;
+}
+.sui-tooltip-popup.color-default {
+  background-color: var(--background-step-3);
+  color: var(--text-normal);
+  border-color: var(--border);
+}
+.sui-tooltip-popup.color-primary {
+  background-color: var(--primary-base);
+  color: var(--text-normal);
+  border-color: var(--primary-hover);
+}
+.sui-tooltip-popup.color-success {
+  background-color: var(--success-base);
+  color: var(--text-normal);
+  border-color: var(--success-hover);
+}
+.sui-tooltip-popup.color-warning {
+  background-color: var(--warning-base);
+  color: var(--text-normal);
+  border-color: var(--warning-hover);
+}
+.sui-tooltip-popup.color-danger {
+  background-color: var(--danger-base);
+  color: var(--text-normal);
+  border-color: var(--danger-hover);
+}
+.sui-tooltip-popup.color-info {
+  background-color: var(--info-base);
+  color: var(--text-normal);
+  border-color: var(--info-hover);
+}
+.sui-tooltip-popup.color-default.variant-outlined {
+  border-color: var(--text-muted);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-primary.variant-outlined {
+  border-color: var(--primary-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-success.variant-outlined {
+  border-color: var(--success-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-warning.variant-outlined {
+  border-color: var(--warning-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-danger.variant-outlined {
+  border-color: var(--danger-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-info.variant-outlined {
+  border-color: var(--info-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.animate {
+  transition: opacity 0.2s ease-out, visibility 0.2s;
+}
+
 .sui-tooltip-pointer {
   position: absolute;
   width: 16px;
   height: 16px;
   z-index: 999;
   background-color: var(--background-step-3);
-  border: solid 2px var(--border);
+  border: solid 1px var(--border);
 }
-.sui-tooltip-position--top .sui-tooltip-pointer {
+.sui-tooltip-popup.variant-default .sui-tooltip-pointer,
+.sui-tooltip-popup.variant-outlined .sui-tooltip-pointer {
+  border-style: solid;
+  border-width: 1px;
+}
+.sui-tooltip-popup.color-default .sui-tooltip-pointer {
+  background-color: var(--background-step-3);
+  border-color: var(--border);
+}
+.sui-tooltip-popup.color-primary .sui-tooltip-pointer {
+  background-color: var(--primary-base);
+  border-color: var(--primary-hover);
+}
+.sui-tooltip-popup.color-success .sui-tooltip-pointer {
+  background-color: var(--success-base);
+  border-color: var(--success-hover);
+}
+.sui-tooltip-popup.color-warning .sui-tooltip-pointer {
+  background-color: var(--warning-base);
+  border-color: var(--warning-hover);
+}
+.sui-tooltip-popup.color-danger .sui-tooltip-pointer {
+  background-color: var(--danger-base);
+  border-color: var(--danger-hover);
+}
+.sui-tooltip-popup.color-info .sui-tooltip-pointer {
+  background-color: var(--info-base);
+  border-color: var(--info-hover);
+}
+.sui-tooltip-popup.color-default.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--text-muted);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-primary.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--primary-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-success.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--success-hover);
+}
+.sui-tooltip-popup.color-warning.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--warning-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-danger.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--danger-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.color-info.variant-outlined .sui-tooltip-pointer {
+  border-color: var(--info-hover);
+  background-color: var(--default-base);
+}
+.sui-tooltip-popup.top .sui-tooltip-pointer {
   bottom: -9px;
   transform: rotateZ(45deg);
   border-left: none;
   border-top: none;
 }
-.sui-tooltip-position--bottom .sui-tooltip-pointer {
+.sui-tooltip-popup.bottom .sui-tooltip-pointer {
   top: -9px;
   transform: rotateZ(45deg);
   border-bottom: none;
   border-right: none;
 }
-.sui-tooltip-position--left .sui-tooltip-pointer {
+.sui-tooltip-popup.left .sui-tooltip-pointer {
   right: -9px;
   transform: rotateZ(45deg);
   border-bottom: none;
   border-left: none;
 }
-.sui-tooltip-position--right .sui-tooltip-pointer {
+.sui-tooltip-popup.right .sui-tooltip-pointer {
   left: -9px;
   transform: rotateZ(45deg);
   border-top: none;

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.css
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.css
@@ -18,9 +18,11 @@
   border-radius: var(--radius-md);
   padding: 0.5rem;
   min-width: 250px;
+  pointer-events: none;
   &[data-visible="true"] {
     opacity: 1;
     visibility: visible;
+    pointer-events: all;
   }
   &.animate {
     transition: opacity 0.2s ease-out, visibility 0.2s;

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.ts
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.ts
@@ -1,0 +1,344 @@
+type Position = 'auto' | 'top' | 'bottom' | 'left' | 'right';
+
+type Point = {
+	x: number;
+	y: number;
+};
+
+interface TooltipOptions {
+	position: 'auto' | 'top' | 'bottom' | 'left' | 'right';
+	enterDelay?: number;
+	exitDelay?: number;
+	hoverOnly?: boolean;
+	animate?: boolean;
+	pointer?: boolean;
+}
+
+class Tooltip {
+	container: HTMLElement;
+	anchor: HTMLElement;
+	tooltip: HTMLElement;
+	options: TooltipOptions;
+	resizeObserver: ResizeObserver | null = null;
+	throttleUpdate: () => void;
+	rafId: number | null = null;
+	offset = 4;
+	edgePadding = 8;
+
+	constructor(container: HTMLElement | null) {
+		if (!container) {
+			throw new Error('Tooltip: Container element is required.');
+		}
+		this.container = container;
+		this.anchor = container.querySelector<HTMLElement>('[data-sui-tooltip-anchor]')!;
+		this.tooltip = container.querySelector<HTMLElement>('[data-sui-tooltip-popup]')!;
+
+		this.options = this.processOptionsFromAttributes();
+		this.throttleUpdate = this.throttle(() => this.update(), 16);
+		this.#init();
+	}
+
+	processOptionsFromAttributes(): TooltipOptions {
+		const jsonOptions = this.container.getAttribute('data-sui-tooltip-options');
+		let options: TooltipOptions = {
+			position: 'auto',
+			enterDelay: 0,
+			exitDelay: 0,
+			hoverOnly: false,
+			animate: true,
+			pointer: true,
+		};
+
+		try {
+			const parsedOptions = jsonOptions ? (JSON.parse(jsonOptions) as Record<string, string>) : {};
+			options = { ...options, ...parsedOptions };
+		} catch {}
+
+		return options;
+	}
+
+	#init() {
+		this.update();
+		this.bindEvents();
+		this.container.dataset.initialized = 'true';
+	}
+
+	update() {
+		if (this.rafId) cancelAnimationFrame(this.rafId);
+		this.rafId = requestAnimationFrame(() => this.updatePosition());
+	}
+
+	bindEvents() {
+		window.addEventListener('resize', () => this.throttleUpdate);
+		window.addEventListener('scroll', () => this.throttleUpdate, true);
+		if (window.ResizeObserver) {
+			this.resizeObserver = new ResizeObserver(() => this.update());
+			this.resizeObserver.observe(this.tooltip);
+			this.resizeObserver.observe(this.anchor);
+		}
+	}
+
+	updatePosition() {
+		const anchorRect = this.anchor.getBoundingClientRect();
+		const tooltipWidth = this.tooltip.offsetWidth;
+		const tooltipHeight = this.tooltip.offsetHeight;
+		const position = this.determinePosition(anchorRect, tooltipWidth, tooltipHeight);
+		const classPrefix = 'sui-tooltip-position';
+		for (const p of ['top', 'bottom', 'left', 'right', 'overlap']) {
+			this.tooltip.classList.toggle(`${classPrefix}--${p}`, p === position);
+		}
+
+		let x: number | null = null;
+		let y: number | null = null;
+		const anchorCenter = {
+			x: anchorRect.left - window.scrollX + anchorRect.width / 2,
+			y: anchorRect.top - window.scrollY + anchorRect.height / 2,
+		};
+
+		switch (position) {
+			case 'top': {
+				x = anchorCenter.x - tooltipWidth / 2;
+				y = anchorRect.top - window.scrollY - tooltipHeight - this.offset;
+				break;
+			}
+			case 'bottom': {
+				x = anchorRect.x - tooltipWidth / 2;
+				y = anchorRect.bottom - window.scrollY + this.offset;
+				break;
+			}
+			case 'left': {
+				x = anchorRect.left - window.scrollX - tooltipWidth - this.offset;
+				y = anchorCenter.y - tooltipHeight / 2;
+				break;
+			}
+			case 'right': {
+				x = anchorRect.right - window.scrollX + this.offset;
+				y = anchorCenter.y - tooltipHeight / 2;
+				break;
+			}
+			default: {
+				x = anchorCenter.x - tooltipWidth / 2;
+				y = anchorRect.top - window.scrollY - tooltipHeight - this.offset;
+				break;
+			}
+		}
+
+		const constraints = this.applyViewportConstraints(x, y, tooltipWidth, tooltipHeight);
+		this.tooltip.style.left = `${constraints.x}px`;
+		this.tooltip.style.top = `${constraints.y}px`;
+
+		if (this.options.pointer) {
+			this.updatePointer(position, anchorCenter, constraints, tooltipWidth, tooltipHeight);
+		}
+	}
+
+	updatePointer(
+		position: Position | 'overlap',
+		anchorCenter: Point,
+		tooltipPosition: Point,
+		tooltipWidth: number,
+		tooltipHeight: number
+	) {
+		const arrow = this.tooltip.querySelector<HTMLElement>('.sui-tooltip-pointer');
+		if (!arrow) return;
+		arrow.style.left = '';
+		arrow.style.top = '';
+		const arrowSize = 8;
+
+		if (position === 'top' || position === 'bottom') {
+			const arrowLeft = anchorCenter.x - tooltipPosition.x - arrowSize;
+			const min = arrowSize;
+			const max = tooltipWidth - arrowSize * 2;
+			arrow.style.left = `${Math.max(min, Math.min(arrowLeft, max))}px`;
+		} else if (position === 'left' || position === 'right') {
+			const arrowTop = anchorCenter.y - tooltipPosition.y - arrowSize;
+			const min = arrowSize;
+			const max = tooltipHeight - arrowSize * 2;
+			arrow.style.top = `${Math.max(min, Math.min(arrowTop, max))}px`;
+		}
+	}
+
+	determinePosition(
+		anchorRect: DOMRect,
+		tooltipWidth: number,
+		tooltipHeight: number
+	): Position | 'overlap' {
+		const position = this.options.position;
+		const anchor = {
+			top: anchorRect.top - window.scrollY,
+			bottom: anchorRect.bottom - window.scrollY,
+			left: anchorRect.left - window.scrollX,
+			right: anchorRect.right - window.scrollX,
+		};
+		const space = {
+			top: anchor.top - this.offset - this.edgePadding,
+			bottom: window.innerHeight - anchor.bottom - this.offset - this.edgePadding,
+			left: anchor.left - this.offset - this.edgePadding,
+			right: window.innerWidth - anchor.right - this.offset - this.edgePadding,
+		};
+		const canFit = {
+			top: space.top >= tooltipHeight,
+			bottom: space.bottom >= tooltipHeight,
+			left: space.left >= tooltipWidth,
+			right: space.right >= tooltipWidth,
+		};
+		const positionHierarchy: {
+			[K in Position]: Exclude<Position, 'auto'>[];
+		} = {
+			top: ['top', 'bottom', 'right', 'left'],
+			bottom: ['bottom', 'top', 'right', 'left'],
+			left: ['left', 'right', 'top', 'bottom'],
+			right: ['right', 'left', 'top', 'bottom'],
+			auto: ['top', 'bottom', 'left', 'right'],
+		};
+		const priority = positionHierarchy[position] || positionHierarchy.auto;
+		for (const pos of priority) {
+			if (canFit[pos]) {
+				return pos;
+			}
+		}
+		return 'overlap';
+	}
+
+	applyViewportConstraints(x: number, y: number, width: number, height: number): Point {
+		let newX: number | null = null;
+		let newY: number | null = null;
+
+		if (x < this.edgePadding) {
+			newX = this.edgePadding;
+		} else if (x + width > window.innerWidth - this.edgePadding) {
+			newX = window.innerWidth - width - this.edgePadding;
+		}
+		if (y < this.edgePadding) {
+			newY = this.edgePadding;
+		} else if (y + height > window.innerHeight - this.edgePadding) {
+			newY = window.innerHeight - height - this.edgePadding;
+		}
+		return {
+			x: newX ?? x,
+			y: newY ?? y,
+		};
+	}
+
+	throttle(fn: (...args: unknown[]) => void, delay: number): () => void {
+		let timeoutId = 0;
+		let lastExecTime = 0;
+		return (...args: unknown[]) => {
+			const currentTime = Date.now();
+			const timeSinceLastExec = currentTime - lastExecTime;
+			clearTimeout(timeoutId);
+			if (timeSinceLastExec >= delay) {
+				fn.apply(this, args);
+				lastExecTime = currentTime;
+			} else {
+				timeoutId = window.setTimeout(() => {
+					fn.apply(this, args);
+					lastExecTime = Date.now();
+				}, delay - timeSinceLastExec);
+			}
+		};
+	}
+
+	show() {
+		this.tooltip.setAttribute('data-visible', 'true');
+		this.anchor.setAttribute('aria-describedby', this.tooltip.id);
+		this.update();
+	}
+
+	hide() {
+		this.tooltip.removeAttribute('data-visible');
+		this.anchor.removeAttribute('aria-describedby');
+	}
+
+	getAnchor() {
+		return this.anchor;
+	}
+
+	destroy() {
+		window.removeEventListener('resize', this.throttleUpdate);
+		window.removeEventListener('scroll', this.throttleUpdate, true);
+		if (this.resizeObserver) {
+			this.resizeObserver.disconnect();
+			this.resizeObserver = null;
+		}
+		if (this.rafId) {
+			cancelAnimationFrame(this.rafId);
+			this.rafId = null;
+		}
+		this.anchor.removeAttribute('aria-describedby');
+	}
+}
+
+function loadTooltips() {
+	const allTooltipElements = document.querySelectorAll<HTMLDivElement>(
+		'.sui-tooltip-container[data-sui-tooltip]'
+	);
+	let activeTooltip: Tooltip | null = null;
+	let enterTimeout: number;
+	let exitTimeout: number;
+
+	const show = (tooltipInstance: Tooltip) => {
+		clearTimeout(exitTimeout);
+		enterTimeout = window.setTimeout(() => {
+			if (activeTooltip && activeTooltip !== tooltipInstance) {
+				activeTooltip.hide();
+			}
+			tooltipInstance.show();
+			activeTooltip = tooltipInstance;
+		}, tooltipInstance.options.enterDelay);
+	};
+
+	const hide = (tooltipInstance: Tooltip) => {
+		clearTimeout(enterTimeout);
+		exitTimeout = window.setTimeout(() => {
+			tooltipInstance.hide();
+			if (activeTooltip === tooltipInstance) {
+				activeTooltip = null;
+			}
+		}, tooltipInstance.options.exitDelay);
+	};
+
+	for (const element of allTooltipElements) {
+		if (element.dataset.initialized) continue;
+		const tooltipInstance: Tooltip = new Tooltip(element);
+		const anchor = tooltipInstance.getAnchor();
+		const popup = tooltipInstance.tooltip;
+
+		anchor.addEventListener('mouseenter', () => show(tooltipInstance));
+		anchor.addEventListener('focus', () => show(tooltipInstance));
+		anchor.addEventListener('mouseleave', () => hide(tooltipInstance));
+		anchor.addEventListener('blur', () => hide(tooltipInstance));
+		anchor.addEventListener('drag', () => hide(tooltipInstance));
+
+		popup.addEventListener('mouseenter', () => clearTimeout(exitTimeout));
+		popup.addEventListener('mouseleave', () => hide(tooltipInstance));
+
+		anchor.addEventListener('click', (e) => {
+			e.stopPropagation();
+			if (activeTooltip === tooltipInstance && !exitTimeout) {
+				hide(tooltipInstance);
+			} else {
+				show(tooltipInstance);
+			}
+		});
+	}
+
+	document.addEventListener('click', (e) => {
+		if (
+			activeTooltip &&
+			!activeTooltip.getAnchor().contains(e.target as Node) &&
+			!activeTooltip.tooltip.contains(e.target as Node)
+		) {
+			hide(activeTooltip);
+		}
+	});
+
+	document.addEventListener('keydown', (e) => {
+		if (e.key === 'Escape' && activeTooltip) {
+			activeTooltip.hide();
+			activeTooltip = null;
+		}
+	});
+}
+
+document.addEventListener('astro:page-load', loadTooltips);

--- a/packages/studiocms_ui/src/components/Tooltip/tooltip.ts
+++ b/packages/studiocms_ui/src/components/Tooltip/tooltip.ts
@@ -125,12 +125,20 @@ class Tooltip {
 			}
 		}
 
-		const constraints = this.applyViewportConstraints(x, y, tooltipWidth, tooltipHeight);
-		this.tooltip.style.left = `${constraints.x}px`;
-		this.tooltip.style.top = `${constraints.y}px`;
+		let finalPosition: Point;
+		const anchorIsVisible = this.isAnchorInViewport(anchorRect);
+
+		if (anchorIsVisible) {
+			finalPosition = this.applyViewportConstraints(x, y, tooltipWidth, tooltipHeight);
+		} else {
+			finalPosition = { x, y };
+		}
+
+		this.tooltip.style.left = `${finalPosition.x}px`;
+		this.tooltip.style.top = `${finalPosition.y}px`;
 
 		if (this.options.pointer) {
-			this.updatePointer(position, anchorCenter, constraints, tooltipWidth, tooltipHeight);
+			this.updatePointer(position, anchorCenter, finalPosition, tooltipWidth, tooltipHeight);
 		}
 	}
 
@@ -195,6 +203,15 @@ class Tooltip {
 			}
 		}
 		return 'overlap';
+	}
+
+	isAnchorInViewport(anchorRect: DOMRect): boolean {
+		return (
+			anchorRect.top < window.innerHeight &&
+			anchorRect.bottom > 0 &&
+			anchorRect.left < window.innerWidth &&
+			anchorRect.right > 0
+		);
 	}
 
 	applyViewportConstraints(x: number, y: number, width: number, height: number): Point {

--- a/packages/studiocms_ui/src/events.d.ts
+++ b/packages/studiocms_ui/src/events.d.ts
@@ -15,6 +15,31 @@ interface CustomEventMap {
 }
 
 /**
+ * Tooltip interface defines the structure of a tooltip API on the window object.
+ */
+interface SuiTooltipApi {
+	instances: Map<string, Tooltip>;
+	/**
+	 * Gets a tooltip instance by its container ID.
+	 * @param id The ID of the tooltip container element.
+	 * @returns The Tooltip instance if found, otherwise undefined.
+	 */
+	get: (id: string) => Tooltip | undefined;
+
+	/**
+	 * Shows a tooltip by its container ID.
+	 * @param id The ID of the tooltip container element.
+	 */
+	show: (id: string) => void;
+
+	/**
+	 * Hides a tooltip by its container ID.
+	 * @param id The ID of the tooltip container element.
+	 */
+	hide: (id: string) => void;
+}
+
+/**
  * Extends the global `Document` interface to include custom event handling methods.
  *
  * @template K - The type of the event name, which must be a key of `CustomEventMap`.
@@ -63,5 +88,18 @@ declare global {
 		 * @param ev - The custom event to be dispatched.
 		 */
 		dispatchEvent<K extends keyof CustomEventMap>(ev: CustomEventMap[K]): void;
+	}
+
+	
+	interface Window {
+		/**
+		 * The StudioCMS UI API, which includes various tools and utilities for the UI.
+		 */
+		sui: {
+			/**
+			 * The tooltip API, which provides methods for managing tooltips in the UI.
+			 */
+			tooltips: SuiTooltipApi;
+		}
 	}
 }

--- a/packages/studiocms_ui/src/index.ts
+++ b/packages/studiocms_ui/src/index.ts
@@ -156,6 +156,7 @@ export default function integration(options: Options = {}): AstroIntegration {
 						'studiocms:ui/scripts/toaster': `import '${resolve('./components/Toast/toaster.js')}';`,
 						'studiocms:ui/scripts/toast': `import '${resolve('./components/Toast/toast.js')}';`,
 						'studiocms:ui/scripts/toggle': `import '${resolve('./components/Toggle/toggle.js')}';`,
+						'studiocms:ui/scripts/tooltip': `import '${resolve('./components/Tooltip/tooltip.js')}';`,
 						'studiocms:ui/scripts/accordion': `import '${resolve('./components/Accordion/accordion.js')}';`,
 						'studiocms:ui/scripts/progress': `import '${resolve('./components/Progress/progress.js')}';`,
 						// Components
@@ -190,6 +191,7 @@ export default function integration(options: Options = {}): AstroIntegration {
 							export { default as Icon } from '${resolve('./components/Icon/Icon.astro')}';
 							export { default as IconBase } from '${resolve('./components/Icon/IconBase.astro')}';
 							export { default as Skeleton } from '${resolve('./components/Skeleton/Skeleton.astro')}';
+							export { default as Tooltip } from '${resolve('./components/Tooltip/Tooltip.astro')}';
 
 							export { ProgressHelper } from '${resolve('./components/Progress/helper.js')}';
 							export { SingleSidebarHelper, DoubleSidebarHelper } from '${resolve('./components/Sidebar/helpers.js')}';

--- a/packages/studiocms_ui/src/virtuals.d.ts
+++ b/packages/studiocms_ui/src/virtuals.d.ts
@@ -38,6 +38,7 @@ declare module 'studiocms:ui/components' {
 	export const TabItem: typeof import('./components/Tabs/TabItem.astro').default;
 	export const Textarea: typeof import('./components/Textarea/Textarea.astro').default;
 	export const Toaster: typeof import('./components/Toast/Toaster.astro').default;
+	export const Tooltip: typeof import('./components/Tooltip/Tooltip.astro').default;
 	export const toast: typeof import('./components/Toast/toast.js').toast;
 	export const Toggle: typeof import('./components/Toggle/Toggle.astro').default;
 	export const User: typeof import('./components/User/User.astro').default;


### PR DESCRIPTION
#### Description

- Adds: Customizable tooltips

#### TODO

- [x] ~~Ensure inline/block displays works properly~~*
- [x] Implement hover only functionality
- [x] Add more examples to the docs
- [x] Add changeset
- [x] Keyboard accessible (interested on how this should behave)
- [x] Add color and variants
- [x] Add programmatic API controls to tooltips
- [x] Fix bug where default open offsets the tooltip when it's off screen


\* Not fully implemented due to an Astro bug see https://github.com/withastro/astro/issues/13970
