### PR TITLE
Refactor virtual modules

### DIFF
--- a/.changeset/cuddly-donuts-move.md
+++ b/.changeset/cuddly-donuts-move.md
@@ -1,0 +1,7 @@
+---
+"@studiocms/ui": minor
+---
+
+Introduce individual component virtual exports alongside the bundled barrel virtual export `'studiocms:ui/components'`
+
+You can now import for example `Button` component from `studiocms:ui/components/button`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,8 +33,5 @@
     "virtuals",
     "vite",
     "withstudiocms"
-  ],
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,8 @@
     "virtuals",
     "vite",
     "withstudiocms"
-  ]
+  ],
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/packages/studiocms_ui/src/index.ts
+++ b/packages/studiocms_ui/src/index.ts
@@ -246,7 +246,7 @@ export default function integration(options: Options = {}): AstroIntegration {
 					injectScript('page-ssr', `import 'studiocms:ui/custom-css';`);
 				}
 
-				// TODO: @louisescher this needs a different icon please... 
+				// TODO: @louisescher this needs a different icon please...
 				// UI Should not be confused with StudioCMS itself
 				addDevToolbarApp({
 					id: 'studiocms-ui-toolbar',
@@ -264,10 +264,10 @@ export default function integration(options: Options = {}): AstroIntegration {
 							export const iconCollections: ('${icons.iconCollections.join("'\n | '")}')[];
 
 							${icons.iconCollections
-							.map((collection) => {
-								return `export const ${collection}: import('@studiocms/ui/types').IconifyJSON;`;
-							})
-							.join('\n')}
+								.map((collection) => {
+									return `export const ${collection}: import('@studiocms/ui/types').IconifyJSON;`;
+								})
+								.join('\n')}
 
 							export type AvailableIcons = (typeof availableIcons)[number];
 							export type IconCollections = (typeof iconCollections)[number];

--- a/packages/studiocms_ui/src/index.ts
+++ b/packages/studiocms_ui/src/index.ts
@@ -137,6 +137,68 @@ export default function integration(options: Options = {}): AstroIntegration {
 
 				icons = createIconifyPrefixCollection(optIcons);
 
+				const componentMap: Record<string, string> = {
+					'studiocms:ui/components/button': `export { default as Button } from '${resolve('./components/Button/Button.astro')}';`,
+					'studiocms:ui/components/divider': `export { default as Divider } from '${resolve('./components/Divider/Divider.astro')}';`,
+					'studiocms:ui/components/input': `export { default as Input } from '${resolve('./components/Input/Input.astro')}';`,
+					'studiocms:ui/components/textarea': `export { default as Textarea } from '${resolve('./components/Textarea/Textarea.astro')}';`,
+					'studiocms:ui/components/row': `export { default as Row } from '${resolve('./components/Row/Row.astro')}';`,
+					'studiocms:ui/components/center': `export { default as Center } from '${resolve('./components/Center/Center.astro')}';`,
+					'studiocms:ui/components/checkbox': `export { default as Checkbox } from '${resolve('./components/Checkbox/Checkbox.astro')}';`,
+					'studiocms:ui/components/toggle': `export { default as Toggle } from '${resolve('./components/Toggle/Toggle.astro')}';`,
+					'studiocms:ui/components/radiogroup': `export { default as RadioGroup } from '${resolve('./components/RadioGroup/RadioGroup.astro')}';`,
+					'studiocms:ui/components/toaster': `
+						export { default as Toaster } from '${resolve('./components/Toast/Toaster.astro')}';
+						export { toast } from '${resolve('./components/Toast/toast.js')}';
+					`,
+					'studiocms:ui/components/card': `export { default as Card } from '${resolve('./components/Card/Card.astro')}';`,
+					'studiocms:ui/components/modal': `
+						export { default as Modal } from '${resolve('./components/Modal/Modal.astro')}';
+						export { ModalHelper } from '${resolve('./components/Modal/modal.js')}';	
+					`,
+					'studiocms:ui/components/select': `
+						export { default as Select } from '${resolve('./components/Select/Select.astro')}';
+						export { default as SearchSelect } from '${resolve('./components/SearchSelect/SearchSelect.astro')}';
+					`,
+					'studiocms:ui/components/dropdown': `
+						export { default as Dropdown } from '${resolve('./components/Dropdown/Dropdown.astro')}';
+						export { DropdownHelper } from '${resolve('./components/Dropdown/dropdown.js')}';	
+					`,
+					'studiocms:ui/components/user': `export { default as User } from '${resolve('./components/User/User.astro')}';`,
+					'studiocms:ui/components/tabs': `
+						export { default as Tabs } from '${resolve('./components/Tabs/Tabs.astro')}';
+						export { default as TabItem } from '${resolve('./components/Tabs/TabItem.astro')}';
+					`,
+					'studiocms:ui/components/accordion': `
+						export { default as Accordion } from '${resolve('./components/Accordion/Accordion.astro')}';
+						export { default as AccordionItem } from '${resolve('./components/Accordion/Item.astro')}';
+					`,
+					'studiocms:ui/components/footer': `export { default as Footer } from '${resolve('./components/Footer/Footer.astro')}';`,
+					'studiocms:ui/components/progress': `
+						export { default as Progress } from '${resolve('./components/Progress/Progress.astro')}';
+						export { ProgressHelper } from '${resolve('./components/Progress/helper.js')}';
+					`,
+					'studiocms:ui/components/sidebar': `
+						export { default as Sidebar } from '${resolve('./components/Sidebar/Single.astro')}';
+						export { default as DoubleSidebar } from '${resolve('./components/Sidebar/Double.astro')}';
+						export { SingleSidebarHelper, DoubleSidebarHelper } from '${resolve('./components/Sidebar/helpers.js')}';
+					`,
+					'studiocms:ui/components/breadcrumbs': `export { default as Breadcrumbs } from '${resolve('./components/Breadcrumbs/Breadcrumbs.astro')}';`,
+					'studiocms:ui/components/group': `export { default as Group } from '${resolve('./components/Group/Group.astro')}';`,
+					'studiocms:ui/components/badge': `export { default as Badge } from '${resolve('./components/Badge/Badge.astro')}';`,
+					'studiocms:ui/components/icon': `
+						export { default as Icon } from '${resolve('./components/Icon/Icon.astro')}';
+						export { default as IconBase } from '${resolve('./components/Icon/IconBase.astro')}';
+					`,
+					'studiocms:ui/components/skeleton': `export { default as Skeleton } from '${resolve('./components/Skeleton/Skeleton.astro')}';`,
+					'studiocms:ui/components/tooltip': `export { default as Tooltip } from '${resolve('./components/Tooltip/Tooltip.astro')}';`,
+				};
+
+				const virtualComponents: Record<string, string> = {
+					...componentMap,
+					'studiocms:ui/components': Object.values(componentMap).join('\n'),
+				};
+
 				addVirtualImports(params, {
 					name: '@studiocms/ui',
 					imports: {
@@ -160,45 +222,7 @@ export default function integration(options: Options = {}): AstroIntegration {
 						'studiocms:ui/scripts/accordion': `import '${resolve('./components/Accordion/accordion.js')}';`,
 						'studiocms:ui/scripts/progress': `import '${resolve('./components/Progress/progress.js')}';`,
 						// Components
-						'studiocms:ui/components': `
-							export { default as Button } from '${resolve('./components/Button/Button.astro')}';
-							export { default as Divider } from '${resolve('./components/Divider/Divider.astro')}';
-							export { default as Input } from '${resolve('./components/Input/Input.astro')}';
-							export { default as Row } from '${resolve('./components/Row/Row.astro')}';
-							export { default as Center } from '${resolve('./components/Center/Center.astro')}';
-							export { default as Textarea } from '${resolve('./components/Textarea/Textarea.astro')}';
-							export { default as Checkbox } from '${resolve('./components/Checkbox/Checkbox.astro')}';
-							export { default as Toggle } from '${resolve('./components/Toggle/Toggle.astro')}';
-							export { default as RadioGroup } from '${resolve('./components/RadioGroup/RadioGroup.astro')}';
-							export { default as Toaster } from '${resolve('./components/Toast/Toaster.astro')}';
-							export { default as Card } from '${resolve('./components/Card/Card.astro')}';
-							export { default as Modal } from '${resolve('./components/Modal/Modal.astro')}';
-							export { default as Select } from '${resolve('./components/Select/Select.astro')}';
-							export { default as SearchSelect } from '${resolve('./components/SearchSelect/SearchSelect.astro')}';
-							export { default as Dropdown } from '${resolve('./components/Dropdown/Dropdown.astro')}';
-							export { default as User } from '${resolve('./components/User/User.astro')}';
-							export { default as Tabs } from '${resolve('./components/Tabs/Tabs.astro')}';
-							export { default as TabItem } from '${resolve('./components/Tabs/TabItem.astro')}';
-							export { default as Accordion } from '${resolve('./components/Accordion/Accordion.astro')}';
-							export { default as AccordionItem } from '${resolve('./components/Accordion/Item.astro')}';
-							export { default as Footer } from '${resolve('./components/Footer/Footer.astro')}';
-							export { default as Progress } from '${resolve('./components/Progress/Progress.astro')}';
-							export { default as Sidebar } from '${resolve('./components/Sidebar/Single.astro')}';
-							export { default as DoubleSidebar } from '${resolve('./components/Sidebar/Double.astro')}';
-							export { default as Breadcrumbs } from '${resolve('./components/Breadcrumbs/Breadcrumbs.astro')}';
-							export { default as Group } from '${resolve('./components/Group/Group.astro')}';
-							export { default as Badge } from '${resolve('./components/Badge/Badge.astro')}';
-							export { default as Icon } from '${resolve('./components/Icon/Icon.astro')}';
-							export { default as IconBase } from '${resolve('./components/Icon/IconBase.astro')}';
-							export { default as Skeleton } from '${resolve('./components/Skeleton/Skeleton.astro')}';
-							export { default as Tooltip } from '${resolve('./components/Tooltip/Tooltip.astro')}';
-
-							export { ProgressHelper } from '${resolve('./components/Progress/helper.js')}';
-							export { SingleSidebarHelper, DoubleSidebarHelper } from '${resolve('./components/Sidebar/helpers.js')}';
-							export { toast } from '${resolve('./components/Toast/toast.js')}';
-							export { ModalHelper } from '${resolve('./components/Modal/modal.js')}';
-							export { DropdownHelper } from '${resolve('./components/Dropdown/dropdown.js')}';
-						`,
+						...virtualComponents,
 
 						'studiocms:ui/utils': `
 							export { ThemeHelper, Theme } from '${resolve('./utils/ThemeHelper.js')}';
@@ -222,6 +246,8 @@ export default function integration(options: Options = {}): AstroIntegration {
 					injectScript('page-ssr', `import 'studiocms:ui/custom-css';`);
 				}
 
+				// TODO: @louisescher this needs a different icon please... 
+				// UI Should not be confused with StudioCMS itself
 				addDevToolbarApp({
 					id: 'studiocms-ui-toolbar',
 					name: 'StudioCMS/UI',
@@ -238,10 +264,10 @@ export default function integration(options: Options = {}): AstroIntegration {
 							export const iconCollections: ('${icons.iconCollections.join("'\n | '")}')[];
 
 							${icons.iconCollections
-								.map((collection) => {
-									return `export const ${collection}: import('@studiocms/ui/types').IconifyJSON;`;
-								})
-								.join('\n')}
+							.map((collection) => {
+								return `export const ${collection}: import('@studiocms/ui/types').IconifyJSON;`;
+							})
+							.join('\n')}
 
 							export type AvailableIcons = (typeof availableIcons)[number];
 							export type IconCollections = (typeof iconCollections)[number];

--- a/packages/studiocms_ui/src/virtuals.d.ts
+++ b/packages/studiocms_ui/src/virtuals.d.ts
@@ -3,11 +3,299 @@ declare module 'studiocms:ui/version' {
 	export default version;
 }
 
-declare module 'studiocms:ui/global-css' {}
+declare module 'studiocms:ui/global-css' { }
 
-declare module 'studiocms:ui/custom-css' {}
+declare module 'studiocms:ui/custom-css' { }
 
-declare module 'studiocms:ui/scripts/*' {}
+declare module 'studiocms:ui/scripts/*' { }
+
+declare module 'studiocms:ui/components/button' {
+	export const Button: typeof import('./components/Button/Button.astro').default;
+}
+
+declare module 'studiocms:ui/components/divider' {
+	export const Divider: typeof import('./components/Divider/Divider.astro').default;
+}
+
+declare module 'studiocms:ui/components/input' {
+	export const Input: typeof import('./components/Input/Input.astro').default;
+}
+
+declare module 'studiocms:ui/components/textarea' {
+	export const Textarea: typeof import('./components/Textarea/Textarea.astro').default;
+}
+
+declare module 'studiocms:ui/components/row' {
+	export const Row: typeof import('./components/Row/Row.astro').default;
+}
+
+declare module 'studiocms:ui/components/center' {
+	export const Center: typeof import('./components/Center/Center.astro').default;
+}
+
+declare module 'studiocms:ui/components/checkbox' {
+	export const Checkbox: typeof import('./components/Checkbox/Checkbox.astro').default;
+}
+
+declare module 'studiocms:ui/components/toggle' {
+	export const Toggle: typeof import('./components/Toggle/Toggle.astro').default;
+}
+
+declare module 'studiocms:ui/components/radiogroup' {
+	export const RadioGroup: typeof import('./components/RadioGroup/RadioGroup.astro').default;
+}
+
+declare module 'studiocms:ui/components/toaster' {
+	export const Toaster: typeof import('./components/Toast/Toaster.astro').default;
+	export const toast: typeof import('./components/Toast/toast.js').toast;
+}
+
+declare module 'studiocms:ui/components/card' {
+	export const Card: typeof import('./components/Card/Card.astro').default;
+}
+
+declare module 'studiocms:ui/components/modal' {
+	export const Modal: typeof import('./components/Modal/Modal.astro').default;
+
+	export class ModalHelper {
+		private element;
+		private cancelButton;
+		private confirmButton;
+		private isForm;
+		private modalForm;
+		/**
+		 * A helper to manage modals.
+		 * @param id The ID of the modal.
+		 * @param triggerID The ID of the element that should trigger the modal.
+		 */
+		constructor(id: string, triggerID?: string);
+		/**
+		 * A helper function which adds event listeners to the modal buttons to close the modal when clicked.
+		 * @param id The ID of the modal.
+		 * @param dismissable Whether the modal is dismissable.
+		 */
+		private addButtonListeners;
+		/**
+		 * A helper function to close the modal when the user clicks outside of it.
+		 */
+		private addDismissiveClickListener;
+		/**
+		 * A function to show the modal.
+		 */
+		show: () => void;
+		/**
+		 * A function to hide the modal.
+		 */
+		hide: () => void;
+		/**
+		 * A function to add another trigger to show the modal with.
+		 * @param elementID The ID of the element that should trigger the modal when clicked.
+		 */
+		bindTrigger: (elementID: string) => void;
+		/**
+		 * Registers a callback for the cancel button.
+		 * @param func The callback function.
+		 */
+		registerCancelCallback: (func: () => void) => void;
+		/**
+		 * Registers a callback for the confirm button.
+		 * @param func The callback function. If the modal is a form, the function will be called with
+		 * the form data as the first argument.
+		 */
+		registerConfirmCallback: (func: (data?: FormData | undefined) => void) => void;
+	}
+}
+
+declare module 'studiocms:ui/components/select' {
+	export const Select: typeof import('./components/Select/Select.astro').default;
+	export const SearchSelect: typeof import('./components/SearchSelect/SearchSelect.astro').default;
+}
+
+declare module 'studiocms:ui/components/dropdown' {
+	export const Dropdown: typeof import('./components/Dropdown/Dropdown.astro').default;
+
+	export class DropdownHelper {
+		private container;
+		private toggleEl;
+		private dropdown;
+		private alignment;
+		private triggerOn;
+		private fullWidth;
+		private focusIndex;
+		active: boolean;
+		/**
+		 * A helper function to interact with dropdowns.
+		 * @param id The ID of the dropdown.
+		 * @param fullWidth Whether the dropdown should be full width. Not needed normally.
+		 */
+		constructor(id: string, fullWidth?: boolean);
+		/**
+		 * Registers a click callback for the dropdown options. Whenever one of the options
+		 * is clicked, the callback will be called with the value of the option.
+		 * @param func The callback function.
+		 */
+		registerClickCallback: (func: (value: string) => void) => void;
+		/**
+		 * Sets up all listeners for the dropdown.
+		 */
+		private initialBehaviorRegistration;
+		/**
+		 * Registers callbacks to hide the dropdown when an option is clicked.
+		 */
+		private initialOptClickRegistration;
+		/**
+		 * A function to toggle the dropdown.
+		 */
+		toggle: () => void;
+		/**
+		 * A function to hide the dropdown.
+		 */
+		hide: () => void;
+		/**
+		 * A function to show the dropdown.
+		 */
+		show: () => void;
+		/**
+		 * A jQuery-like function to hide the dropdown when clicking outside of it.
+		 * @param element The element to hide when clicking outside of it.
+		 */
+		private hideOnClickOutside;
+	}
+}
+
+declare module 'studiocms:ui/components/user' {
+	export const User: typeof import('./components/User/User.astro').default;
+}
+
+declare module 'studiocms:ui/components/tabs' {
+	export const Tabs: typeof import('./components/Tabs/Tabs.astro').default;
+	export const TabItem: typeof import('./components/Tabs/TabItem.astro').default;
+}
+
+declare module 'studiocms:ui/components/footer' {
+	export const Footer: typeof import('./components/Footer/Footer.astro').default;
+}
+
+declare module 'studiocms:ui/components/progress' {
+	export const Progress: typeof import('./components/Progress/Progress.astro').default;
+
+	export class ProgressHelper {
+		private bar;
+		private progress;
+		private value;
+		private max;
+		constructor(id: string);
+		getValue(): number;
+		setValue(value: number): void;
+		getMax(): number;
+		setMax(value: number): void;
+		getPercentage(): number;
+	}
+}
+
+declare module 'studiocms:ui/components/badge' {
+	export const Badge: typeof import('./components/Badge/Badge.astro').default;
+}
+
+declare module 'studiocms:ui/components/accordion' {
+	export const Accordion: typeof import('./components/Accordion/Accordion.astro').default;
+	export const AccordionItem: typeof import('./components/Accordion/Item.astro').default;
+}
+
+declare module 'studiocms:ui/components/sidebar' {
+	export const Sidebar: typeof import('./components/Sidebar/Single.astro').default;
+	export const DoubleSidebar: typeof import('./components/Sidebar/Double.astro').default;
+
+	export class SingleSidebarHelper {
+		private sidebar;
+		private sidebarToggle?;
+		/**
+		 * A helper to manage the sidebar with.
+		 * @param toggleID The ID of the element that should toggle the sidebar.
+		 */
+		constructor(toggleID?: string);
+		/**
+		 * A helper function register an element which should toggle the sidebar.
+		 * @param elementID The ID of the element that should toggle the sidebar.
+		 */
+		toggleSidebarOnClick: (elementID: string) => void;
+		/**
+		 * A helper function to hide the sidebar when an element is clicked.
+		 * @param elementID The ID of the element that should hide the sidebar.
+		 */
+		hideSidebarOnClick: (elementID: string) => void;
+		/**
+		 * A helper function to show the sidebar when an element is clicked.
+		 * @param elementID The ID of the element that should show the sidebar.
+		 */
+		showSidebarOnClick: (elementID: string) => void;
+		/**
+		 * A function to hide the sidebar.
+		 */
+		hideSidebar: () => void;
+		/**
+		 * A function to show the sidebar.
+		 */
+		showSidebar: () => void;
+	}
+
+	export class DoubleSidebarHelper {
+		private sidebarsContainer;
+		/**
+		 * A helper to manage the double sidebar with.
+		 */
+		constructor();
+		/**
+		 * A helper function to hide the sidebar when an element is clicked.
+		 * @param elementID The ID of the element that should hide the sidebar.
+		 */
+		hideSidebarOnClick: (elementID: string) => void;
+		/**
+		 * A helper function to show the outer sidebar when an element is clicked.
+		 * @param elementID The ID of the element that should show the outer sidebar.
+		 */
+		showOuterOnClick: (elementID: string) => void;
+		/**
+		 * A helper function to show the inner sidebar when an element is clicked.
+		 * @param elementID The ID of the element that should show the inner sidebar.
+		 */
+		showInnerOnClick: (elementID: string) => void;
+		/**
+		 * A function to show the inner sidebar.
+		 */
+		showInnerSidebar: () => void;
+		/**
+		 * A function to show the outer sidebar.
+		 */
+		showOuterSidebar: () => void;
+		/**
+		 * A function to hide the sidebar altogether.
+		 */
+		hideSidebar: () => void;
+	}
+
+}
+
+declare module 'studiocms:ui/components/breadcrumbs' {
+	export const Breadcrumbs: typeof import('./components/Breadcrumbs/Breadcrumbs.astro').default;
+}
+
+declare module 'studiocms:ui/components/group' {
+	export const Group: typeof import('./components/Group/Group.astro').default;
+}
+
+declare module 'studiocms:ui/components/icon' {
+	export const Icon: typeof import('./components/Icon/Icon.astro').default;
+	export const IconBase: typeof import('./components/Icon/IconBase.astro').default;
+}
+
+declare module 'studiocms:ui/components/skeleton' {
+	export const Skeleton: typeof import('./components/Skeleton/Skeleton.astro').default;
+}
+
+declare module 'studiocms:ui/components/tooltip' {
+	export const Tooltip: typeof import('./components/Tooltip/Tooltip.astro').default;
+}
 
 declare module 'studiocms:ui/components' {
 	export const Accordion: typeof import('./components/Accordion/Accordion.astro').default;

--- a/packages/studiocms_ui/src/virtuals.d.ts
+++ b/packages/studiocms_ui/src/virtuals.d.ts
@@ -3,11 +3,11 @@ declare module 'studiocms:ui/version' {
 	export default version;
 }
 
-declare module 'studiocms:ui/global-css' { }
+declare module 'studiocms:ui/global-css' {}
 
-declare module 'studiocms:ui/custom-css' { }
+declare module 'studiocms:ui/custom-css' {}
 
-declare module 'studiocms:ui/scripts/*' { }
+declare module 'studiocms:ui/scripts/*' {}
 
 declare module 'studiocms:ui/components/button' {
 	export const Button: typeof import('./components/Button/Button.astro').default;
@@ -273,7 +273,6 @@ declare module 'studiocms:ui/components/sidebar' {
 		 */
 		hideSidebar: () => void;
 	}
-
 }
 
 declare module 'studiocms:ui/components/breadcrumbs' {


### PR DESCRIPTION
This pull request enhances the `@studiocms/ui` package by introducing individual virtual exports for each UI component, in addition to the existing bundled barrel export. This allows developers to import only the specific components they need, resulting in more efficient and modular code. The implementation also refactors the way these exports are registered internally to support this new flexibility.

### Virtual exports and import improvements

* Added individual virtual exports for each UI component (e.g., `'studiocms:ui/components/button'`), enabling more granular imports and reducing bundle size for consumers. The existing `'studiocms:ui/components'` barrel export remains available. [[1]](diffhunk://#diff-238aaddf8055b0ffb0ec1eb44e6531fc7a205f803404bfca36a7c9fce8945f2dR140-R201) [[2]](diffhunk://#diff-e4b6078d950f0083fdfb80f242e6116ff171f280fbf3ddadda721539245fb351R1-R7)
* Refactored the export registration logic in `index.ts` to use a `componentMap` and `virtualComponents` object, simplifying the management and extension of component exports. [[1]](diffhunk://#diff-238aaddf8055b0ffb0ec1eb44e6531fc7a205f803404bfca36a7c9fce8945f2dR140-R201) [[2]](diffhunk://#diff-238aaddf8055b0ffb0ec1eb44e6531fc7a205f803404bfca36a7c9fce8945f2dL163-R225)

### Developer experience

* Added a TODO note regarding the need for a distinct icon for the UI dev toolbar app to avoid confusion with StudioCMS itself.

### Documentation

* Updated the changeset to document the new minor version and describe the new import capability for individual components.