### PR TITLE
Setup 1.0.0 beta release workflow

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "build-scripts": "0.0.14",
+    "docs": "0.0.1",
+    "@studiocms/ui": "0.4.17"
+  },
+  "changesets": []
+}

--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - v1.0.0
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This pull request introduces a couple of small but important changes related to release management and CI configuration. It adds a pre-release configuration for the project and updates the CI workflow to trigger on an additional branch.

Release and versioning:

* Added a `.changeset/pre.json` file to enable pre-release mode with the "beta" tag and set initial versions for `build-scripts`, `docs`, and `@studiocms/ui`.

CI/CD configuration:

* Updated `.github/workflows/ci-push-main.yml` to trigger the workflow on pushes to both the `main` and `v1.0.0` branches.