### PR TITLE
fix: Button focus is hidden behind other buttons in group

### DIFF
--- a/.changeset/fifty-apricots-beam.md
+++ b/.changeset/fifty-apricots-beam.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Fixes the focus outline of buttons within groups sometimes being hidden behind other buttons in the same group.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "build": "pnpm --filter @studiocms/* build",
     "dev": "pnpm --stream --filter @studiocms/* --filter docs -r -parallel dev",
-
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm build && pnpm --filter docs build",
     "docs:preview": "pnpm --filter docs preview",

--- a/packages/studiocms_ui/src/components/Group/group.css
+++ b/packages/studiocms_ui/src/components/Group/group.css
@@ -20,3 +20,7 @@
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }
+
+.sui-group .sui-button:focus-visible {
+	z-index: 2;
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes the focus outline of buttons within groups sometimes being hidden behind other buttons in the same group. 

**This PR should not automatically close the issue - it's going to be merged into the v1.0.0 branch and released with #85.**
<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->