### PR TITLE
feat: Add optional icons & help text to inputs

### DIFF
--- a/.changeset/sour-readers-drum.md
+++ b/.changeset/sour-readers-drum.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Adds optional icons and help texts to inputs

--- a/docs/src/content/docs/docs/components/input.mdx
+++ b/docs/src/content/docs/docs/components/input.mdx
@@ -98,12 +98,11 @@ the `FormData` returned by a submission. Here's an example showing how to set bo
 If no name is set, a random one is generated for the component.
 :::
 
-
 ### Icons
 
 You can pass the name of an icon using the `icon` prop to display it inside of the input on the left side. To show the icon on the
 right hand side of the input, or explicitly set the position, pass an object to the `icon` prop containing the `name` and `position`
-of the icon.
+of the icon:
 
 <Tabs>
   <TabItem label="Preview">
@@ -113,13 +112,34 @@ of the icon.
     </PreviewCard>
   </TabItem>
   <TabItem label="Code">
-    ```astro "isRequired" "name='example-input'" showLinenumbers title="IconsExample.astro"
+    ```astro "icon='heroicons:bolt-20-solid'" "icon={{ name: 'heroicons:bolt-20-solid', position: 'right' }}" "name='example-input'" showLinenumbers title="IconsExample.astro"
     ---
     import { Input } from 'studiocms:ui/components/input';
     ---
 
-    <Input label="Label" placeholder="Placeholder" icon="heroicons:bolt-20-solid" />
-    <Input placeholder="Placeholder" icon={{ name: "heroicons:bolt-20-solid", position: "right" }} />
+    <Input label='Label' placeholder='Placeholder' icon='heroicons:bolt-20-solid' />
+    <Input placeholder='Placeholder' icon={{ name: 'heroicons:bolt-20-solid', position: 'right' }} />
+    ```
+  </TabItem>
+</Tabs>
+
+### Description
+
+You can add a description to be shown below the input by using the `description` prop:
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Input label='Label' placeholder='Placeholder' description='This is some text to help the user understand the input!' />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro "description='This is some text to help the user understand the input!'" showLinenumbers title="DescriptionExample.astro"
+    ---
+    import { Input } from 'studiocms:ui/components/input';
+    ---
+
+    <Input label='Label' placeholder='Placeholder' description='This is some text to help the user understand the input!' />
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/docs/components/input.mdx
+++ b/docs/src/content/docs/docs/components/input.mdx
@@ -97,3 +97,29 @@ the `FormData` returned by a submission. Here's an example showing how to set bo
 :::note
 If no name is set, a random one is generated for the component.
 :::
+
+
+### Icons
+
+You can pass the name of an icon using the `icon` prop to display it inside of the input on the left side. To show the icon on the
+right hand side of the input, or explicitly set the position, pass an object to the `icon` prop containing the `name` and `position`
+of the icon.
+
+<Tabs>
+  <TabItem label="Preview">
+    <PreviewCard>
+      <Input label="Label" placeholder="Placeholder" icon="heroicons:bolt-20-solid" />
+      <Input placeholder="Placeholder" icon={{ name: "heroicons:bolt-20-solid", position: "right" }} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="Code">
+    ```astro "isRequired" "name='example-input'" showLinenumbers title="IconsExample.astro"
+    ---
+    import { Input } from 'studiocms:ui/components/input';
+    ---
+
+    <Input label="Label" placeholder="Placeholder" icon="heroicons:bolt-20-solid" />
+    <Input placeholder="Placeholder" icon={{ name: "heroicons:bolt-20-solid", position: "right" }} />
+    ```
+  </TabItem>
+</Tabs>

--- a/packages/studiocms_ui/src/components/Input/Input.astro
+++ b/packages/studiocms_ui/src/components/Input/Input.astro
@@ -5,7 +5,6 @@ import type { HTMLAttributes } from 'astro/types';
 import { generateID } from '../../utils/generateID.js';
 import './input.css';
 import { AstroError } from 'astro/errors';
-import { undefined } from 'astro:schema';
 import Icon from '../Icon/Icon.astro';
 
 /**

--- a/packages/studiocms_ui/src/components/Input/Input.astro
+++ b/packages/studiocms_ui/src/components/Input/Input.astro
@@ -45,12 +45,16 @@ interface Props extends HTMLAttributes<'input'> {
 	 */
 	class?: string;
 	/**
-	 * An optional icon to be shown in the icon.
+	 * An optional icon to be shown in the input.
 	 */
 	icon?: AvailableIcons | {
 		name: AvailableIcons;
 		position: 'left' | 'right';
 	};
+	/**
+	 * A description to be shown below the input
+	 */
+	description?: string;
 }
 
 const {
@@ -63,6 +67,7 @@ const {
 	disabled = false,
 	class: className,
 	icon,
+	description,
 	...props
 } = Astro.props;
 
@@ -100,4 +105,7 @@ const iconPos = icon ? typeof icon === "string" || (typeof icon === "object" && 
     value={defaultValue}
 		{...props}
   />
+	{description && (
+		<span class="sui-input-desc">{description}</span>
+	)}
 </label>

--- a/packages/studiocms_ui/src/components/Input/Input.astro
+++ b/packages/studiocms_ui/src/components/Input/Input.astro
@@ -1,7 +1,12 @@
 ---
+// @ts-ignore - This is a TypeGenerated Module, available in dev thanks to manual d.ts file - This comment is here because this causes a type-error during build
+import { type AvailableIcons } from 'studiocms:ui/icons';
 import type { HTMLAttributes } from 'astro/types';
 import { generateID } from '../../utils/generateID.js';
 import './input.css';
+import { AstroError } from 'astro/errors';
+import { undefined } from 'astro:schema';
+import Icon from '../Icon/Icon.astro';
 
 /**
  * The props for the input component.
@@ -39,6 +44,13 @@ interface Props extends HTMLAttributes<'input'> {
 	 * Additional classes to apply to the input.
 	 */
 	class?: string;
+	/**
+	 * An optional icon to be shown in the icon.
+	 */
+	icon?: AvailableIcons | {
+		name: AvailableIcons;
+		position: 'left' | 'right';
+	};
 }
 
 const {
@@ -50,8 +62,18 @@ const {
 	isRequired = false,
 	disabled = false,
 	class: className,
+	icon,
 	...props
 } = Astro.props;
+
+if (typeof icon === "object") {
+	if (!icon.name) throw new AstroError("Missing icon name for input!");
+	if (!icon.position) throw new AstroError("Missing icon position for input!");
+
+	if (!["left", "right"].includes(icon.position)) throw new AstroError("Invalid icon position for input!");
+}
+
+const iconPos = icon ? typeof icon === "string" || (typeof icon === "object" && icon.position === "left") ? "left" : "right" : undefined;
 ---
 
 <label for={name} class="sui-input-label" class:list={[disabled && "disabled"]}>
@@ -60,13 +82,19 @@ const {
 			{label} <span class="req-star">{isRequired && "*"}</span>
 		</span>
 	)}
+	{typeof icon === "string" && (
+		<Icon name={icon} width={20} height={20} class="input-icon icon-left" />
+	)}
+	{typeof icon === "object" && (
+		<Icon name={icon.name} width={20} height={20} class="input-icon" class:list={[`icon-${iconPos}`]}  />
+	)}
   <input
     placeholder={placeholder}
     name={name}
     id={name}
     type={type}
     class="sui-input"
-		class:list={[className]}
+		class:list={[className, iconPos && `has-icon icon-${iconPos}`]}
     required={isRequired}
     disabled={disabled}
     value={defaultValue}

--- a/packages/studiocms_ui/src/components/Input/input.css
+++ b/packages/studiocms_ui/src/components/Input/input.css
@@ -45,6 +45,10 @@
 	font-weight: 700;
 }
 
+.sui-input-desc {
+	font-size: .825rem;
+}
+
 .input-icon {
 	position: absolute;
 	top: 50%;
@@ -61,6 +65,14 @@
 
 .label + .input-icon {
 	top: calc(50% + 14px);
+}
+
+.label + .input-icon:has(~ .sui-input-desc) {
+	top: calc(50%);
+}
+
+.input-icon:has(~ .sui-input-desc):not(.label + .input-icon) {
+	top: calc(50% - 14px);
 }
 
 .sui-input.has-icon.icon-left {

--- a/packages/studiocms_ui/src/components/Input/input.css
+++ b/packages/studiocms_ui/src/components/Input/input.css
@@ -3,6 +3,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: .25rem;
+	position: relative;
 }
 
 .sui-input-label.disabled {
@@ -42,4 +43,30 @@
 .req-star {
 	color: var(--danger-base);
 	font-weight: 700;
+}
+
+.input-icon {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+}
+
+.input-icon.icon-left {
+	left: 0.75rem;
+}
+
+.input-icon.icon-right {
+	right: 0.75rem;
+}
+
+.label + .input-icon {
+	top: calc(50% + 14px);
+}
+
+.sui-input.has-icon.icon-left {
+	padding-left: calc(1.5rem + 20px);
+}
+
+.sui-input.has-icon.icon-right {
+	padding-right: calc(1.5rem + 20px);
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR adds the option to add an icon to any input, at the start or at the end.
- It also adds the option to add help text to the inputs.

**This PR should not automatically close the feature request issues - it's going to be merged into the v1.0.0 branch and released with #85.**

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->