### PR TITLE
fix: Ensure buttons in dropdowns within groups have proper styles

### DIFF
--- a/.changeset/moody-seas-perform.md
+++ b/.changeset/moody-seas-perform.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Fixes buttons within dropdowns not displaying properly within a group

--- a/packages/studiocms_ui/src/components/Group/group.css
+++ b/packages/studiocms_ui/src/components/Group/group.css
@@ -5,6 +5,7 @@
 }
 
 .sui-group > .sui-button:not(:first-child):not(:last-child),
+.sui-group .sui-dropdown-container:not(:first-child):not(:last-child) .sui-button,
 .sui-group > .sui-badge:not(:first-child):not(:last-child) {
 	border-radius: 0;
 }

--- a/packages/studiocms_ui/src/components/Group/group.css
+++ b/packages/studiocms_ui/src/components/Group/group.css
@@ -4,19 +4,21 @@
 	align-items: center;
 }
 
-.sui-group .sui-button:not(:first-child):not(:last-child),
-.sui-group .sui-badge:not(:first-child):not(:last-child) {
+.sui-group > .sui-button:not(:first-child):not(:last-child),
+.sui-group > .sui-badge:not(:first-child):not(:last-child) {
 	border-radius: 0;
 }
 
-.sui-group .sui-button:first-child,
-.sui-group .sui-badge:first-child {
+.sui-group > .sui-button:first-child,
+.sui-group .sui-dropdown-container:first-child .sui-button,
+.sui-group > .sui-badge:first-child {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 }
 
-.sui-group .sui-button:last-child,
-.sui-group .sui-badge:last-child {
+.sui-group > .sui-button:last-child,
+.sui-group .sui-dropdown-container:last-child .sui-button,
+.sui-group > .sui-badge:last-child {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR fixes an issue where buttons nested within dropdowns within a group would not have the proper border radius applied to them

**This PR should not automatically close the bug report issue - it's going to be merged into the v1.0.0 branch and released with #85.**

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->…radius