### PR TITLE
feat: Bump pnpm to 10.17 and configure minimumReleaseAge

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,6 +1,6 @@
 biome = "1.9.2"
 node = "20.14.0"
-pnpm = "9.5.0"
+pnpm = "10.17.0"
 
 [plugins]
 biome = "source:https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/biome/plugin.toml"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "root",
   "private": true,
-  "packageManager": "pnpm@9.5.0",
+  "packageManager": "pnpm@10.17.0",
   "engines": {
     "node": "20.14.0"
   },
   "scripts": {
     "build": "pnpm --filter @studiocms/* build",
     "dev": "pnpm --stream --filter @studiocms/* --filter docs -r -parallel dev",
-
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm build && pnpm --filter docs build",
     "docs:preview": "pnpm --filter docs preview",
@@ -23,13 +22,13 @@
     "ci:snapshot": "pnpx pkg-pr-new publish --pnpm --compact './packages/*' "
   },
   "dependencies": {
-      "@actions/core": "^1.11.1",
-      "@biomejs/biome": "^1.9.4",
-      "@changesets/cli": "2.27.9",
-      "@changesets/config": "3.0.3",
-      "@changesets/changelog-github": "^0.5.0",
-      "build-scripts": "workspace:*",
-      "pkg-pr-new": "^0.0.35",
-      "typescript": "catalog:"
+    "@actions/core": "^1.11.1",
+    "@biomejs/biome": "^1.9.4",
+    "@changesets/cli": "2.27.9",
+    "@changesets/config": "3.0.3",
+    "@changesets/changelog-github": "^0.5.0",
+    "build-scripts": "workspace:*",
+    "pkg-pr-new": "^0.0.35",
+    "typescript": "catalog:"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,21 +1,34 @@
 packages:
-  - "packages/*"
-  - "build-scripts"
-  - "docs"
+  - packages/*
+  - build-scripts
+  - docs
 
 catalog:
-  "@astrojs/check": ^0.9.4
-  "@astrojs/node": ^9.0.0
-  "@fontsource-variable/onest": 5.1.0
-  "@iconify-json/heroicons": ^1.2.1
-  "@iconify/utils": ^2.1.33
-  "@sentry/astro": ^8.42.0
-  "@types/node": ^20.14.11
-  pathe: ^1.1.2
+  '@astrojs/check': ^0.9.4
+  '@astrojs/node': ^9.0.0
+  '@fontsource-variable/onest': 5.1.0
+  '@iconify-json/heroicons': ^1.2.1
+  '@iconify/utils': ^2.1.33
+  '@sentry/astro': ^8.42.0
+  '@types/node': ^20.14.11
   astro: ^5.1.1
+  pathe: ^1.1.2
   typescript: ^5.7.2
 
 catalogs:
   peers:
     astro: ^4.5 || ^5.0.0-beta.0
     vite: ^5.0.0 || ^6.0.0
+
+minimumReleaseAge: 4320
+
+minimumReleaseAgeExclude:
+  - studiocms
+  - '@studiocms/*'
+  - '@withstudiocms/*'
+
+onlyBuiltDependencies:
+  - '@biomejs/biome'
+  - '@parcel/watcher'
+  - esbuild
+  - sharp


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
This PR bumps the PNPM version to 10.17.0 and enables the new `minimumReleaseAge` feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded package manager to pnpm 10.17.0.
  - Introduced workspace release controls: minimumReleaseAge (4320), exclusions for studiocms-related packages, and an onlyBuiltDependencies list (@biomejs/biome, @parcel/watcher, esbuild, sharp).
- Style
  - Formatting/quoting cleanups across configuration files (pnpm-workspace.yaml, package.json, .prototools), including re-indentation, quote normalization, and end-of-file newline adjustments. No changes to dependency names/versions or plugin configuration content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->