### PR TITLE
add: custom set ids on TabItem/Tabs for testing

### DIFF
--- a/packages/studiocms_ui/src/components/Tabs/TabItem.astro
+++ b/packages/studiocms_ui/src/components/Tabs/TabItem.astro
@@ -23,13 +23,19 @@ interface Props {
 	 * Whether the tab should be active by default.
 	 */
 	active?: boolean;
+
+	/**
+	 * The unique ID of the tab. If not provided, a random ID will be generated.
+	 */
+	id?: string;
 }
 
 const id = generateID('tab');
 
-const { icon, label, color = 'primary', active = false } = Astro.props;
+const { icon, label, color = 'primary', active = false, id: customId } = Astro.props;
 ---
 <sui-tab-item
+	id={customId ?? id}
 	data-icon={icon}
 	data-label={label}
 	data-color={color}

--- a/packages/studiocms_ui/src/components/Tabs/Tabs.astro
+++ b/packages/studiocms_ui/src/components/Tabs/Tabs.astro
@@ -34,6 +34,11 @@ interface Props {
 	 * The alignment of the tabs. Defaults to `left`.
 	 */
 	align?: 'left' | 'center' | 'right';
+
+	/**
+	 * The ID of the tab.
+	 */
+	id?: string;
 }
 
 /**
@@ -133,6 +138,7 @@ const markTabAsActive = (tabId: string, html: string): string => {
 const uniqueId = generateID('sui-tabs-container');
 
 const {
+	id: customId,
 	syncKey: originalSyncKey,
 	storage = 'session',
 	variant = 'default',
@@ -150,7 +156,7 @@ const containerId = generateID('sui-tabs-container');
 
 <div 
   class="sui-tabs-container"
-  id={containerId}
+  id={customId ?? containerId}
   data-sync-key={syncKey}
   data-unique-id={uniqueId}
   data-storage-strategy={storage}


### PR DESCRIPTION
#### Description

- Closes #117
- Adds the ability to set custom IDs on Tabs and TabItem components, making test-ability easier