### PR TITLE
fix: renamed css variable to correct name

### DIFF
--- a/.changeset/thirty-snails-do.md
+++ b/.changeset/thirty-snails-do.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Fixed undeclared css variables for flat button style

--- a/packages/studiocms_ui/src/components/Button/button.css
+++ b/packages/studiocms_ui/src/components/Button/button.css
@@ -362,7 +362,7 @@
 	}
 
 	.sui-button.success.flat {
-		background-color: var(--success-flat-base);
+		background-color: var(--success-flat);
 		color: hsl(143, 59%, 20%);
 	}
 
@@ -375,7 +375,7 @@
 	}
 
 	.sui-button.warning.flat {
-		background-color: var(--warning-flat-base);
+		background-color: var(--warning-flat);
 		color: hsl(48, 78%, 20%);
 	}
 


### PR DESCRIPTION
#### Description

- Fixes the flat success button by renaming the background variable used to the correct name
