### PR TITLE
Add Simplified Chinese UI component docs

### DIFF
--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -15,7 +15,7 @@ export const locales = {
 	// fr: { label: 'Français', lang: 'fr' },
 	// it: { label: 'Italiano', lang: 'it' },
 	// id: { label: 'Bahasa Indonesia', lang: 'id' },
-	// 'zh-cn': { label: '简体中文', lang: 'zh-CN' },
+	'zh-cn': { label: '简体中文', lang: 'zh-CN' },
 	// 'pt-br': { label: 'Português do Brasil', lang: 'pt-BR' },
 	// 'pt-pt': { label: 'Português', lang: 'pt-PT' },
 	// ko: { label: '한국어', lang: 'ko' },

--- a/docs/src/content/docs/zh-cn/docs/changelog.md
+++ b/docs/src/content/docs/zh-cn/docs/changelog.md
@@ -1,0 +1,139 @@
+---
+# Warning: This file is generated automatically. Do not edit!
+title: Release Notes
+description: Release notes for the @studiocms/ui package.
+editUrl: false
+---
+
+This document contains release notes for the `@studiocms/ui` package.
+For more information, see the [CHANGELOG file](https://github.com/withstudiocms/ui/blob/main/packages/studiocms_ui/CHANGELOG.md)
+
+## 0.4.11
+
+- [#69](https://github.com/withstudiocms/ui/pull/69) [`ef29352`](https://github.com/withstudiocms/ui/commit/ef29352b03b87a34da163ade2aae6652ce819251) Thanks [@louisescher](https://github.com/louisescher)! - Fixes broken styles for flat success buttons in light mode and starlight tabs when used in cards
+
+## 0.4.10
+
+- [#63](https://github.com/withstudiocms/ui/pull/63) [`dc7b723`](https://github.com/withstudiocms/ui/commit/dc7b723c86ae9bafd9b8dba626be2345a92a2568) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Adds a value prop to the checkbox
+
+## 0.4.9
+
+- [#61](https://github.com/withstudiocms/ui/pull/61) [`59f4c05`](https://github.com/withstudiocms/ui/commit/59f4c05d303686b139fef632d69c2edf49895ea3) Thanks [@louisescher](https://github.com/louisescher)! - Fixes card footers to be hidden should they have no content
+
+## 0.4.8
+
+- [#59](https://github.com/withstudiocms/ui/pull/59) [`f71057d`](https://github.com/withstudiocms/ui/commit/f71057dcc00468d9c4f5584cbbc384dc987c136a) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Add viewbox attribute for IconBase component
+
+## 0.4.7
+
+- [#56](https://github.com/withstudiocms/ui/pull/56) [`40ae2ea`](https://github.com/withstudiocms/ui/commit/40ae2eaa60f0b0df6e0447be5f3e362cbb9bff76) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Add option to disable global CSS injection and allow users to import the global css themselves.
+
+  Basic Example of how to import:
+
+  ```astro
+  ---
+  import "studiocms:ui/global-css";
+  ---
+  ```
+
+## 0.4.6
+
+- [#52](https://github.com/withstudiocms/ui/pull/52) [`65eea2c`](https://github.com/withstudiocms/ui/commit/65eea2cff78c2c38314de9b3fe4b65173c81ea90) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Update Input component to allow search type
+
+## 0.4.5
+
+- [#50](https://github.com/withstudiocms/ui/pull/50) [`51d5565`](https://github.com/withstudiocms/ui/commit/51d556504790741ad3b6cd23092b9be0a92e8157) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - fix weird icon sizing during build
+
+## 0.4.4
+
+- [#48](https://github.com/withstudiocms/ui/pull/48) [`4a43e03`](https://github.com/withstudiocms/ui/commit/4a43e031b2395ca1cf72c8343638f5836178944e) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Fix Icon component requiring functions from Iconify Utils lib during runtime as well as extend usage possibilities.
+
+  NEW:
+
+  - `IconBase` component exported from `studiocms:ui/components` which allows passing custom image collections from Iconify.
+
+  Updated:
+
+  - `Icon` component to use this new system.
+
+## 0.4.3
+
+- [#46](https://github.com/withstudiocms/ui/pull/46) [`29ea967`](https://github.com/withstudiocms/ui/commit/29ea967c2cee935715de0f4787b603d69997e84b) Thanks [@louisescher](https://github.com/louisescher)! - Fixes icons getting cut off in certain circumstances and changes dropdown links to include icons
+
+## 0.4.2
+
+- [#44](https://github.com/withstudiocms/ui/pull/44) [`99a2f79`](https://github.com/withstudiocms/ui/commit/99a2f7959b4269d47c99c87a06ea6711c74a373e) Thanks [@louisescher](https://github.com/louisescher)! - Fixes compatibility issues with Astro view transitions
+
+## 0.4.1
+
+- [#40](https://github.com/withstudiocms/ui/pull/40) [`641e4b0`](https://github.com/withstudiocms/ui/commit/641e4b09574eb3d54c08b52be65e36233c2bbd6a) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Update publish config and files included
+
+## 0.4.0
+
+- [#36](https://github.com/withstudiocms/ui/pull/36) [`07e2d9e`](https://github.com/withstudiocms/ui/commit/07e2d9e5a473bdcd516bf4d43e8274988ec796e6) Thanks [@louisescher](https://github.com/louisescher)! - Implement Build step and migrate all exported components into virtual modules
+
+  Instead of `@studiocms/ui/components` use `studiocms:ui/components`
+
+  For more information see https://ui.studiocms.dev
+
+- [#36](https://github.com/withstudiocms/ui/pull/36) [`07e2d9e`](https://github.com/withstudiocms/ui/commit/07e2d9e5a473bdcd516bf4d43e8274988ec796e6) Thanks [@louisescher](https://github.com/louisescher)! - Add a few new components:
+
+  - Accordion
+  - Badge
+  - Breadcrumbs
+  - Group
+  - Progress
+  - Sidebar
+
+  Add two new colors
+
+  - `info` (Blue)
+  - `monochrome` (Black/White)
+
+  Add the ability to pass a CSS file for customization of all colors
+
+## 0.3.2
+
+- [#33](https://github.com/withstudiocms/ui/pull/33) [`58e223c`](https://github.com/withstudiocms/ui/commit/58e223c861321e95c8db064be67e28e4563b4ff3) Thanks [@louisescher](https://github.com/louisescher)! - Fix tabs not being displayed correctly & dividers displaying backgrounds for empty slots
+
+## 0.3.1
+
+- [#27](https://github.com/withstudiocms/ui/pull/27) [`6b0b58f`](https://github.com/withstudiocms/ui/commit/6b0b58fbbe2a92d4bce7fa44c587164b8f2f53e5) Thanks [@louisescher](https://github.com/louisescher)! - Add pathe as a dependency to deal with path issues on Windows
+
+## 0.3.0
+
+- [#18](https://github.com/withstudiocms/ui/pull/18) [`e471e11`](https://github.com/withstudiocms/ui/commit/e471e1129a30ff2a5b019366a8eb7bbbf2abb73e) Thanks [@louisescher](https://github.com/louisescher)! - The Accessibility Update
+
+  This version of `@studiocms/ui` includes a lot of improvements to the documentation and components. The most important changes include the move to
+  an integration-based system and a massive keyboard accessibility overhaul (thanks to [HiDeoo](https://github.com/HiDeoo) for the feedback on this)!
+
+  ### Components
+
+  - Added a new `<Tabs />` component based on the tabs on the homepage.
+  - Updated the `<Card />` component to include a new "filled" style.
+
+  ### Utilities
+
+  - Moved the `ThemeHelper` class to its own category in the docs.
+
+  ### Accessibility
+
+  - Overhauled the keyboard accessibility on all components to make them adhere to the ARIA standards.
+
+## 0.1.0
+
+- [#1](https://github.com/withstudiocms/ui/pull/1) [`14be139`](https://github.com/withstudiocms/ui/commit/14be139876aa2c5ab75fea07ee338afefece6f56) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Added a new footer component, made accessibility improvements and preparations for first stable release
+
+- [#1](https://github.com/withstudiocms/ui/pull/1) [`14be139`](https://github.com/withstudiocms/ui/commit/14be139876aa2c5ab75fea07ee338afefece6f56) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - - Update `<Input />` component's available types
+
+- [#1](https://github.com/withstudiocms/ui/pull/1) [`14be139`](https://github.com/withstudiocms/ui/commit/14be139876aa2c5ab75fea07ee338afefece6f56) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Added a new searchable select component and improved accessibility for normal selects
+
+- [#1](https://github.com/withstudiocms/ui/pull/1) [`14be139`](https://github.com/withstudiocms/ui/commit/14be139876aa2c5ab75fea07ee338afefece6f56) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Created new UI Library in preparations for the new StudioCMS Dashboard project
+
+- [#1](https://github.com/withstudiocms/ui/pull/1) [`14be139`](https://github.com/withstudiocms/ui/commit/14be139876aa2c5ab75fea07ee338afefece6f56) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Added a theme helper and theme toggle component
+
+- [#1](https://github.com/withstudiocms/ui/pull/1) [`14be139`](https://github.com/withstudiocms/ui/commit/14be139876aa2c5ab75fea07ee338afefece6f56) Thanks [@Adammatthiesen](https://github.com/Adammatthiesen)! - Adjusted persistent toasts to include an outline for better visibility
+
+## 0.0.1
+
+- Initial Testing release

--- a/docs/src/content/docs/zh-cn/docs/components/Sidebar.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/Sidebar.mdx
@@ -1,0 +1,117 @@
+---
+title: 侧边栏
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+:::caution[需要辅助函数]
+此组件需要使用**辅助函数**。请务必仔细阅读文档，以了解如何使用它。
+:::
+
+我们在 StudioCMS 中使用的侧边栏组件，旨在实现最大的可定制性。由于篇幅限制，本页面仅展示代码，而不展示组件本身。请查看 StudioCMS 仪表板以了解它们的外观。
+
+## 用法
+
+### 单侧边栏
+
+两者中较简单的一个。一个带有内置移动端断点的侧边栏。
+
+```astro title="SingleSidebarExample.astro"
+---
+import { Sidebar, Button } from 'studiocms:ui/components';
+---
+
+<Sidebar>
+  {/* 您的侧边栏内容放在这里 */}
+</Sidebar>
+<Button id="my-toggle">
+切换侧边栏
+</Button>
+<script>
+import { SingleSidebarHelper } from 'studiocms:ui/components';
+
+new SingleSidebarHelper('my-toggle');
+</script>
+```
+
+由您来创建一个切换组件。一旦侧边栏可以被隐藏（断点为 `840px`），就应该显示该组件。
+
+辅助工具提供了一些有用的方法来与侧边栏交互：
+
+```ts title="SingleSidebarHelperExample.ts"
+import { SingleSidebarHelper } from 'studiocms:ui/components';
+
+const sidebar = new SingleSidebarHelper('my-toggle');
+
+// 向指定元素（通过其 ID 指定）添加事件监听器，
+// 在点击时隐藏侧边栏。仅适用于移动端视口。
+sidebar.hideSidebarOnClick('my-element');
+
+// 向指定元素（通过其 ID 指定）添加事件监听器，
+// 在点击时显示侧边栏。仅适用于移动端视口。
+sidebar.showSidebarOnClick('my-element');
+
+// 隐藏侧边栏。
+sidebar.hideSidebar();
+
+// 显示侧边栏。
+sidebar.showSidebar();
+```
+
+### 双侧边栏
+
+一个更复杂的版本，包含两个窗格，且具有不同的断点。
+
+```astro title="DoubleSidebarExample.astro"
+---
+import { DoubleSidebar } from 'studiocms:ui/components';
+---
+
+<DoubleSidebar>
+  <div slot="outer">
+    {/* 您的外部侧边栏内容放在这里 */}
+  </div>
+  <div slot="inner">
+    {/* 您的内部侧边栏内容放在这里 */}
+  </div>
+</DoubleSidebar>
+<script>
+import { DoubleSidebarHelper } from 'studiocms:ui/components';
+
+const sidebar = new DoubleSidebarHelper();
+</script>
+```
+
+由于双侧边栏的性质更为复杂，最好采用以下设置：
+
+- 在大于 `1200px` 的屏幕上，不显示任何切换按钮，并完整显示侧边栏。
+- 在小于 `1200px` 且大于 `840px` 的屏幕上，仅显示一个切换按钮，用于在内部和外部侧边栏之间切换。
+- 在小于 `840px` 的屏幕上，当外部导航栏隐藏时显示一个切换按钮以显示它，当它显示时显示一个切换按钮以在外部和内部之间切换。
+
+为了帮助您管理侧边栏状态，辅助工具提供了以下方法：
+
+```ts title="DoubleSidebarHelperExample.astro"
+import { DoubleSidebarHelper } from 'studiocms:ui/components';
+
+const sidebar = new DoubleSidebarHelper();
+
+// 注册一个元素，在点击时将完全隐藏侧边栏
+sidebar.hideSidebarOnClick('my-element');
+
+// 注册一个元素，在点击时将显示外部侧边栏
+sidebar.showOuterOnClick('my-element');
+
+// 注册一个元素，在点击时将显示内部侧边栏
+sidebar.showInnerOnClick('my-element');
+
+// 注册一个元素，在点击时将在内部和外部侧边栏之间切换
+sidebar.toggleStateOnClick('my-element');
+
+// 所有其他功能懂得都懂：
+sidebar.showInnerSidebar();
+sidebar.showOuterSidebar();
+sidebar.toggleSidebarState();
+sidebar.hideSidebar();
+```

--- a/docs/src/content/docs/zh-cn/docs/components/accordion.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/accordion.mdx
@@ -1,0 +1,139 @@
+---
+title: 折叠
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Accordion, AccordionItem } from 'studiocms:ui/components';
+
+一个折叠块。用于创建小块的附加信息。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Accordion>
+        <AccordionItem open>
+          <div slot="summary">这是摘要</div>
+          <div>这是详细信息</div>
+        </AccordionItem>
+        <AccordionItem>
+          <div slot="summary">这是第二个摘要</div>
+          <div>这是第二个详细信息</div>
+        </AccordionItem>
+      </Accordion>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="AccordionExample.astro"
+    ---
+    import { Accordion, AccordionItem } from 'studiocms:ui/components';
+    ---
+
+    <Accordion>
+      <AccordionItem open>
+        <div slot="summary">这是摘要</div>
+        <div>这是详细信息</div>
+      </AccordionItem>
+      <AccordionItem>
+        <div slot="summary">这是第二个摘要</div>
+        <div>这是第二个详细信息</div>
+      </AccordionItem>
+    </Accordion>
+    ```
+  </TabItem>
+</Tabs>
+
+### 默认打开某一项
+
+你可以将 `open` 属性传递给任何 `<AccordionItem>`，以使其默认打开，如上例所示。
+
+### 样式
+
+折叠块有多种不同的样式：
+
+- `outlined`（默认）
+- `separated`
+- `filled`
+- `blank`
+
+它们可以通过折叠块父元素上的 `style` 属性使用。以下是一个使用 `filled` 样式的折叠块：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Accordion style="filled">
+        <AccordionItem open>
+          <div slot="summary">这是摘要</div>
+          <div>这是详细信息</div>
+        </AccordionItem>
+        <AccordionItem>
+          <div slot="summary">这是第二个摘要</div>
+          <div>这是第二个详细信息</div>
+        </AccordionItem>
+      </Accordion>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="AccordionStyleExample.astro"
+    ---
+    import { Accordion, AccordionItem } from 'studiocms:ui/components';
+    ---
+
+    <Accordion style="filled">
+      <AccordionItem open>
+        <div slot="summary">这是摘要</div>
+        <div>这是详细信息</div>
+      </AccordionItem>
+      <AccordionItem>
+        <div slot="summary">这是第二个摘要</div>
+        <div>这是第二个详细信息</div>
+      </AccordionItem>
+    </Accordion>
+    ```
+  </TabItem>
+</Tabs>
+
+### 多项同时打开
+
+默认情况下，用户可以同时打开折叠块中的多项。你可以通过在 `<Accordion>` 元素上设置 `multipleOpen` 属性为 false 来更改此行为：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Accordion multipleOpen={false}>
+        <AccordionItem open>
+          <div slot="summary">这是摘要</div>
+          <div>这是详细信息</div>
+        </AccordionItem>
+        <AccordionItem>
+          <div slot="summary">这是第二个摘要</div>
+          <div>这是第二个详细信息</div>
+        </AccordionItem>
+      </Accordion>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="AccordionStyleExample.astro"
+    ---
+    import { Accordion, AccordionItem } from 'studiocms:ui/components';
+    ---
+
+    <Accordion multipleOpen={false}>
+      <AccordionItem open>
+        <div slot="summary">这是摘要</div>
+        <div>这是详细信息</div>
+      </AccordionItem>
+      <AccordionItem>
+        <div slot="summary">这是第二个摘要</div>
+        <div>这是第二个详细信息</div>
+      </AccordionItem>
+    </Accordion>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/badge.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/badge.mdx
@@ -1,0 +1,154 @@
+---
+title: 徽章
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+import { Badge } from 'studiocms:ui/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+
+一个徽章组件，开箱即用支持不同的颜色、尺寸和状态。您还可以根据需要自定义它！
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Badge label="徽章" icon="sparkles-16-solid" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="BadgeExample.astro"
+    ---
+    import { Badge } from 'studiocms:ui/components';
+    ---
+
+    <Badge label="徽章" icon="sparkles-16-solid" />
+    ```
+  </TabItem>
+</Tabs>
+
+### 颜色
+
+徽章组件支持以下颜色：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Badge label="主要" color="primary" />
+      <Badge label="成功" color="success" />
+      <Badge label="警告" color="warning" />
+      <Badge label="危险" color="danger" />
+      <Badge label="信息" color="info" />
+      <Badge label="单色" color="mono" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="BadgeColorExample.astro"
+    ---
+    import { Badge } from 'studiocms:ui/components';
+    ---
+
+    <Badge label="主要" color="primary" />
+    <Badge label="成功" color="success" />
+    <Badge label="警告" color="warning" />
+    <Badge label="危险" color="danger" />
+    <Badge label="信息" color="info" />
+    <Badge label="单色" color="mono" />
+    ```
+  </TabItem>
+</Tabs>
+
+### 变体
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Badge label="默认" variant="default" />
+      <Badge label="描边" variant="outlined" />
+      <Badge label="扁平" variant="flat" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="BadgeSizeExample.astro"
+    ---
+    import { Badge } from 'studiocms:ui/components';
+    ---
+
+    <Badge label="默认" variant="default" />
+    <Badge label="描边" variant="outlined" />
+    <Badge label="扁平" variant="flat" />
+    ```
+  </TabItem>
+</Tabs>
+
+### 圆角
+
+您可以通过设置 `rounding` 属性来更改徽章的边框半径：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Badge label="全圆" rounding="full" />
+      <Badge label="半圆" rounding="semi" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="BadgeSizeExample.astro"
+    ---
+    import { Badge } from 'studiocms:ui/components';
+    ---
+
+    <Badge label="全圆" rounding="full" />
+    <Badge label="半圆" rounding="semi" />
+    ```
+  </TabItem>
+</Tabs>
+
+### 尺寸
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Badge label="小" size="sm" />
+      <Badge label="中" size="md" />
+      <Badge label="大" size="lg" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="BadgeSizeExample.astro"
+    ---
+    import { Badge } from 'studiocms:ui/components';
+    ---
+
+    <Badge label="小" size="sm" />
+    <Badge label="中" size="md" />
+    <Badge label="大" size="lg" />
+    ```
+  </TabItem>
+</Tabs>
+
+### 图标
+
+您可以通过传递 `icon` 属性，在徽章中使用 [HeroIcons](https://heroicons.com/) 的内置图标：
+
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Badge label="带图标的徽章" icon="sparkles-16-solid" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="IconExample.astro"
+    ---
+    import { Badge } from 'studiocms:ui/components';
+    ---
+
+    <Badge label="带图标的徽章" icon="sparkles-16-solid" />
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/breadcrumbs.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/breadcrumbs.mdx
@@ -1,0 +1,83 @@
+---
+title: 路径
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+import { Breadcrumbs } from 'studiocms:ui/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+
+一个简单的路径组件！用于指示当前页面在导航层级中的位置。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Breadcrumbs 
+        segments={[
+          { label: "首页", segment: "" },
+          { label: "文档", segment: "docs" },
+          { label: "组件", segment: "components" },
+          { label: "路径", segment: "breadcrumbs" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ButtonExample.astro"
+    ---
+    import { Breadcrumbs } from 'studiocms:ui/components';
+    ---
+
+    <Breadcrumbs 
+      segments={[
+        { label: "首页", segment: "" },
+        { label: "文档", segment: "docs" },
+        { label: "组件", segment: "components" },
+        { label: "路径", segment: "breadcrumbs" },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 更改分隔符
+
+您可以通过传递 `separator` 属性来更改分隔符。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Breadcrumbs 
+        segments={[
+          { label: "首页", segment: "" },
+          { label: "文档", segment: "docs" },
+          { label: "组件", segment: "components" },
+          { label: "路径", segment: "breadcrumbs" },
+        ]}
+        separator="/"
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ButtonExample.astro"
+    ---
+    import { Breadcrumbs } from 'studiocms:ui/components';
+    ---
+
+    <Breadcrumbs 
+      segments={[
+        { label: "首页", segment: "" },
+        { label: "文档", segment: "docs" },
+        { label: "组件", segment: "components" },
+        { label: "路径", segment: "breadcrumbs" },
+      ]}
+      separator="/"
+    />
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/button.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/button.mdx
@@ -1,0 +1,277 @@
+---
+i18nReady: true
+title: 按钮
+sidebar:
+  badge:
+    text: New Colors!
+    variant: tip
+---
+
+import { Button } from 'studiocms:ui/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+
+一个按钮组件，开箱即用支持不同的颜色、尺寸和状态。您还可以根据需要自定义它！
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color='primary'>
+        按钮
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ButtonExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+
+    <Button color='primary'>
+      按钮
+    </Button>
+    ```
+  </TabItem>
+</Tabs>
+
+### 禁用
+
+您可以通过 `disabled` 属性禁用按钮组件：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color='primary' disabled>
+        按钮
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "disabled" showLinenumbers title="DisabledButtonExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+
+    <Button color='primary' disabled>
+      按钮
+    </Button>
+    ```
+  </TabItem>
+</Tabs>
+
+### 尺寸
+
+按钮组件支持三种不同的默认尺寸：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color='primary' size='sm'>
+        按钮 (小)
+      </Button>
+      <Button color='primary'>
+        按钮 (默认)
+      </Button>
+      <Button color='primary' size='lg'>
+        按钮 (大)
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /size='(?:sm|lg)'/ showLinenumbers title="ButtonSizesExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+
+    <Button color='primary' size='sm'>
+      按钮 (小)
+    </Button>
+    <Button color='primary'>
+      按钮 (默认)
+    </Button>
+    <Button color='primary' size='lg'>
+      按钮 (大)
+    </Button>
+    ```
+  </TabItem>
+</Tabs>
+
+### 颜色
+
+按钮组件支持以下七种默认颜色：
+- 默认
+- 主要
+- 成功
+- 警告
+- 危险
+- 信息
+- 单色
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color='default'>
+        默认
+      </Button>
+      <Button color='primary'>
+        主要
+      </Button>
+      <Button color='success'>
+        成功
+      </Button>
+      <Button color='warning'>
+        警告
+      </Button>
+      <Button color='danger'>
+        危险
+      </Button>
+      <Button color='info'>
+        信息
+      </Button>
+      <Button color='mono'>
+        单色
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /color='[a-z]+'/ showLinenumbers title="ButtonColorsExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+
+    <Button color='default'>
+      默认
+    </Button>
+    <Button color='primary'>
+      主要
+    </Button>
+    <Button color='success'>
+      成功
+    </Button>
+    <Button color='warning'>
+      警告
+    </Button>
+    <Button color='danger'>
+      危险
+    </Button>
+    <Button color='info'>
+      信息
+    </Button>
+    <Button color='mono'>
+      单色
+    </Button>
+    ```
+  </TabItem>
+</Tabs>
+
+### 变体
+
+除了颜色外，按钮组件还支持三种不同的变体：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color='primary'>
+        默认
+      </Button>
+      <Button color='primary' variant="outlined">
+        描边
+      </Button>
+      <Button color='primary' variant="flat">
+        扁平
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /variant=\"[a-z]+\"/ showLinenumbers title="ButtonVariantsExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+
+    <Button color='primary'>
+      默认
+    </Button>
+    <Button color='primary' variant="outlined">
+      描边
+    </Button>
+    <Button color='primary' variant="flat">
+      扁平
+    </Button>
+    ```
+  </TabItem>
+</Tabs>
+
+### Polymorphic（渲染为锚标签）
+
+得益于 Astro 的 `Polymorphic` 类型，您可以将按钮的父组件更改为任何所需的 HTML 标签！
+以下是一个将按钮渲染为 `<a>` 标签的示例：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color='primary' target="_blank" as='a' href="https://studiocms.dev">
+        studiocms.dev
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "as='a'" showLinenumbers title="ButtonPolymorphicExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+  
+    <Button color='primary' target="_blank" as='a' href="https://studiocms.dev">
+      studiocms.dev
+    </Button>
+    ```
+  </TabItem>
+</Tabs>
+
+### 自定义样式
+
+如前所述，您可以为按钮组件应用自定义样式！以下是一个渐变按钮的示例，展示如何实现：
+
+:::danger[生产环境中的自定义样式]
+由于 Astro 以一种很奇怪的方式打包 CSS，您的自定义样式在生产环境中会被覆盖，**除非您使用 `!important` 或将其设置为内联样式！**
+:::
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button style="background-image: linear-gradient(to top right, #a07cee, #4ff8d2); color: black; font-weight: 600;">
+        自定义按钮
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码（内联样式）">
+    ```astro /style="(?:[^"]*)"/ showLinenumbers title="ButtonCustomStylesExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+  
+    <Button style="background-image: linear-gradient(to top right, #a07cee, #4ff8d2); color: black; font-weight: 600;">
+      自定义按钮
+    </Button>
+    ```
+  </TabItem>
+  <TabItem label="代码（使用 !important）">
+    ```astro ins={9-13} showLinenumbers title="ButtonCustomStylesExample.astro"
+    ---
+    import { Button } from 'studiocms:ui/components';
+    ---
+  
+    <Button class="custom-btn">
+      自定义按钮
+    </Button>
+    <style>
+      .custom-btn {
+        background-image: linear-gradient(to top right, #a07cee, #4ff8d2) !important;
+        color: black !important;
+        font-weight: 600 !important;
+      }
+    </style>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/card.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/card.mdx
@@ -1,0 +1,169 @@
+---
+i18nReady: true
+title: 卡片
+---
+
+import { Card } from 'studiocms:ui/components';
+import { Tabs, TabItem, Badge } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+
+一个用于包装其他内容的简单卡片组件！ 
+
+## 使用方法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Card>
+        内容
+      </Card>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="CardExample.astro"
+    ---
+    import { Card } from 'studiocms:ui/components';
+    ---
+
+    <Card>
+      内容
+    </Card>
+    ```
+  </TabItem>
+</Tabs>
+
+### 变体 <Badge text="New！" variant="tip" />
+
+不仅仅是带边框的卡片，您可以使用 `variant` 属性来更改卡片的外观。将其设置为
+`filled` 可以拥有一个带有填充背景的卡片：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Card variant="filled">
+        内容
+      </Card>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "variant='filled'" showLinenumbers title="FullVariantExample.astro"
+    ---
+    import { Card } from 'studiocms:ui/components';
+    ---
+
+    <Card variant='filled'>
+      内容
+    </Card>
+    ```
+  </TabItem>
+</Tabs>
+
+### 全宽与全高
+
+您可以使用 `fullWidth` 参数将卡片设置为扩展至其父容器的宽度：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Card fullWidth>
+        内容
+      </Card>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "fullWidth" showLinenumbers title="FullVariantExample.astro"
+    ---
+    import { Card } from 'studiocms:ui/components';
+    ---
+
+    <Card fullWidth>
+      内容
+    </Card>
+    ```
+  </TabItem>
+</Tabs>
+
+此外，您可以使用 `fullHeight` 参数将卡片设置为扩展至其父容器的高度：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Card fullHeight>
+        内容
+      </Card>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "fullHeight" showLinenumbers title="FullHeightCardExample.astro"
+    ---
+    import { Card } from 'studiocms:ui/components';
+    ---
+
+    <Card fullHeight>
+      内容
+    </Card>
+    ```
+  </TabItem>
+</Tabs>
+
+### 页眉与页脚 <Badge text="新增！" variant="tip" />
+
+卡片组件支持页眉和页脚插槽：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Card>
+        <h4 slot='header'>页眉内容</h4>
+        <p>
+          Lorem ipsum dolor sit amet. Et nulla cumque et suscipit molestiae est quam eaque et placeat iste est 
+          velit dignissimos aut totam voluptatum qui eveniet nostrum. Aut neque reprehenderit est vero debitis 
+          in inventore voluptas ut dolores facilis et voluptatibus quibusdam aut dolorum sunt non vitae sequi.
+        </p>
+        <span slot='footer'>页脚内容</span>
+      </Card>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /slot='(?:header|footer)'/ showLinenumbers title="CardSlotsExample.astro"
+    ---
+    import { Card } from 'studiocms:ui/components';
+    ---
+
+    <Card>
+      <h4 slot='header'>页眉内容</h4>
+      <p>
+        Lorem ipsum dolor sit amet. Et nulla cumque et suscipit molestiae est quam eaque et placeat iste est 
+        velit dignissimos aut totam voluptatum qui eveniet nostrum. Aut neque reprehenderit est vero debitis 
+        in inventore voluptas ut dolores facilis et voluptatibus quibusdam aut dolorum sunt non vitae sequi.
+      </p>
+      <span slot='footer'>页脚内容</span>
+    </Card>
+    ```
+  </TabItem>
+</Tabs>
+
+### Polymorphic
+
+卡片可以变成您想要的任何东西，字面意思就是这样！卡片支持 Astro 的 `Polymorphic` 类型，这意味着您可以通过传递 `as` 属性将卡片渲染为您想要的任何元素。这是一个渲染为 `<a>` 标签而不是 `<div>` 的卡片： 
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Card as="a" href="https://studiocms.dev">
+        studiocms.dev
+      </Card>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "as='a'" showLinenumbers title="CardPolymorphicExample.astro"
+    ---
+    import { Card } from 'studiocms:ui/components';
+    ---
+
+    <Card as='a' href='https://studiocms.dev'>
+      studiocms.dev
+    </Card>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/center.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/center.mdx
@@ -1,0 +1,35 @@
+---
+i18nReady: true
+title: 居中
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Center } from 'studiocms:ui/components';
+
+<small>
+这里只是为了给 Jumper 添堵。你好 Jumper！
+</small>
+
+玩笑归玩笑。这是一个包装组件，通过将 `flex` 或 `grid` 的折腾抽象为一个组件，可以为你节省一些时间。你可以像这样使用它：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Center>
+        Hi Jumper!
+      </Center>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="CenterExample.astro"
+    ---
+    import { Center } from 'studiocms:ui/components';
+    ---
+
+    <Center>
+      Hi Jumper!
+    </Center>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/checkbox.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/checkbox.mdx
@@ -1,0 +1,127 @@
+---
+i18nReady: true
+title: 复选框
+sidebar:
+  badge:
+    text: New Colors!
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Checkbox, Row } from 'studiocms:ui/components';
+
+支持多种尺寸和颜色的自定义复选框组件。兼容表单。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Checkbox label="标签" color="primary" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="CheckboxExample.astro"
+    ---
+    import { Checkbox } from 'studiocms:ui/components';
+    ---
+
+    <Checkbox label="标签" color='primary' />
+    ```
+  </TabItem>
+</Tabs>
+
+### 尺寸
+
+复选框有三种不同的尺寸：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Row>
+        <Checkbox label="小" color="primary" size="sm" defaultChecked />
+        <Checkbox label="中" color="primary" defaultChecked />
+        <Checkbox label="大" color="primary" size="lg" defaultChecked />
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /size='[a-z]+'/ showLinenumbers title="CheckboxSizesExample.astro"
+    ---
+    import { Checkbox } from 'studiocms:ui/components';
+    ---
+
+    <Checkbox label='小' color='primary' size='sm' defaultChecked />
+    <Checkbox label='中' color='primary' defaultChecked />
+    <Checkbox label='大' color='primary' size='lg' defaultChecked />
+    ```
+  </TabItem>
+</Tabs>
+
+### 颜色
+
+复选框组件支持所有默认颜色。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Row>
+        <Checkbox label="默认" defaultChecked />
+        <Checkbox label="主要" color="primary" defaultChecked />
+        <Checkbox label="成功" color="success" defaultChecked />
+        <Checkbox label="警告" color="warning" defaultChecked />
+        <Checkbox label="危险" color="danger" defaultChecked />
+        <Checkbox label="信息" color="info" defaultChecked />
+        <Checkbox label="单色" color="mono" defaultChecked />
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /color='[a-z]+'/ showLinenumbers title="CheckboxColorsExample.astro"
+    ---
+    import { Checkbox } from 'studiocms:ui/components';
+    ---
+
+    <Checkbox label='默认' defaultChecked />
+    <Checkbox label='主要' color='primary' defaultChecked />
+    <Checkbox label='成功' color='success' defaultChecked />
+    <Checkbox label='警告' color='warning' defaultChecked />
+    <Checkbox label='危险' color='danger' defaultChecked />
+    <Checkbox label="信息" color="info" defaultChecked />
+    <Checkbox label="单色" color="mono" defaultChecked />
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+如果您想在表单中使用此组件，您很幸运！您可以传递两个属性：`isRequired` 和 `name`。
+
+第一个属性的作用如其名，而后者设置 `name` 属性，以便您可以访问复选框，例如，在提交返回的 `FormData` 中。以下是一个演示如何同时设置这两个属性的示例：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Checkbox label="必填 & 自定义名称" color="primary" isRequired name='required-checkbox' />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro ins={8-9} showLinenumbers title="CheckboxFormExample.astro"
+    ---
+    import { Checkbox } from 'studiocms:ui/components';
+    ---
+
+    <Checkbox 
+      label='必填 & 自定义名称'
+      color='primary'
+      name='required-checkbox'
+      isRequired
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+:::note
+如果未设置名称，则会为该组件生成一个随机名称。
+:::

--- a/docs/src/content/docs/zh-cn/docs/components/divider.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/divider.mdx
@@ -1,0 +1,45 @@
+---
+i18nReady: true
+title: 分隔符
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Divider } from 'studiocms:ui/components';
+
+一个简单的分隔符。允许在中间显示标签，这有助于分隔侧边栏或其他结构化内容。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Divider>
+        分隔符
+      </Divider>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="DividerExample.astro"
+    ---
+    import { Divider } from 'studiocms:ui/components';
+    ---
+
+    <Divider>
+      分隔符
+    </Divider>
+    ```
+  </TabItem>
+</Tabs>
+
+## 更改标签背景颜色
+
+在某些情况下，您的分隔符可能位于一个不使用默认页面背景颜色的元素上。在这种情况下，您可以使用 `background` 属性将其更改为正确的颜色。
+
+```astro "background='background-step-1'" showLinenumbers title="DividerBackgroundExample.astro"
+---
+import { Divider } from 'studiocms:ui/components';
+---
+
+<Divider background='background-step-1'>
+  分隔符
+</Divider>
+```

--- a/docs/src/content/docs/zh-cn/docs/components/dropdown.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/dropdown.mdx
@@ -1,0 +1,306 @@
+---
+i18nReady: true
+title: 下拉菜单
+sidebar:
+  badge:
+    text: New Colors!
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import DropdownScript from '~/components/DropdownScript.astro';
+import { Dropdown, Button, Row } from 'studiocms:ui/components';
+
+:::caution[需要辅助函数]
+此组件需要使用**辅助函数**。请务必仔细阅读文档，以了解如何使用它。
+:::
+
+一个下拉菜单组件，为您处理所有繁琐的细节，并额外增加了对程序化触发的支持。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Dropdown id='usage-dropdown' options={[{ label: '选项 1', value: 'opt-1'},{ label: '选项 2', value: 'opt-2'}]}>
+        <Button color="primary">
+          触发下拉菜单
+        </Button>
+      </Dropdown>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="DropdownExample.astro"
+    ---
+    import { Dropdown, Button } from 'studiocms:ui/components';
+    ---
+
+    <Dropdown 
+      id='dropdown' 
+      options={[
+        { label: '选项 1', value: 'opt-1'},
+        { label: '选项 2', value: 'opt-2'},
+      ]}
+    >
+      <Button color='primary'>
+        触发下拉菜单
+      </Button>
+    </Dropdown>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { DropdownHelper } from 'studiocms:ui/components';
+
+    const dropdown = new DropdownHelper('dropdown');
+    ```
+  </TabItem>
+</Tabs>
+
+### 下拉菜单位置
+
+您可以通过提供 `align` 属性来更改下拉菜单位置。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Row>
+        <Dropdown id='align-start-dropdown' align='start' options={[{ label: '选项 1', value: 'opt-1'},{ label: '选项 2', value: 'opt-2'}]}>
+          <Button color="primary">
+            靠左对齐
+          </Button>
+        </Dropdown>
+        <Dropdown id='align-center-dropdown' options={[{ label: '选项 1', value: 'opt-1'},{ label: '选项 2', value: 'opt-2'}]}>
+          <Button color="primary">
+            居中对齐
+          </Button>
+        </Dropdown>
+        <Dropdown id='align-end-dropdown' align='end' options={[{ label: '选项 1', value: 'opt-1'},{ label: '选项 2', value: 'opt-2'}]}>
+          <Button color="primary">
+            靠右对齐
+          </Button>
+        </Dropdown>
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "align='start'" showLinenumbers title="DropdownAlignStartExample.astro"
+    ---
+    import { Dropdown, Button } from 'studiocms:ui/components';
+    ---
+
+    <Dropdown 
+      id='dropdown'
+      options={[
+        { label: '选项 1', value: 'opt-1'},
+        { label: '选项 2', value: 'opt-2'},
+      ]}
+      align='start'
+    >
+      <Button color='primary'>
+        起始对齐
+      </Button>
+    </Dropdown>
+    
+    <!-- 为简洁起见，省略了其他按钮 -->
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { DropdownHelper } from 'studiocms:ui/components';
+
+    const dropdown = new DropdownHelper('dropdown');
+    ```
+  </TabItem>
+</Tabs>
+
+### 右键触发
+
+您可以指示下拉菜单包装器仅在其子元素被右键单击时显示下拉菜单：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Dropdown id='right-click-dropdown' triggerOn='right' options={[{ label: '选项 1', value: 'opt-1'},{ label: '选项 2', value: 'opt-2'}]}>
+        <Button color="primary">
+          右键点击
+        </Button>
+      </Dropdown>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "triggerOn='right'" showLinenumbers title="DropdownRightClickExample.astro"
+    ---
+    import { Dropdown, Button } from 'studiocms:ui/components';
+    ---
+
+    <Dropdown
+      id='dropdown'
+      options={[
+        { label: '选项 1', value: 'opt-1'},
+        { label: '选项 2', value: 'opt-2'},
+      ]}
+      triggerOn='right'
+    >
+      <Button color='primary'>
+        右键点击
+      </Button>
+    </Dropdown>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { DropdownHelper } from 'studiocms:ui/components';
+
+    const dropdown = new DropdownHelper('dropdown');
+    ```
+  </TabItem>
+</Tabs>
+
+:::note
+您也可以通过使用 `triggerOn='both'` 属性来指示下拉菜单在左键和右键单击时都触发。
+:::
+
+### 禁用
+
+您可以通过传递 `disabled` 属性来禁用下拉菜单。
+
+```astro "disabled" showLinenumbers title="DropdownDisabledExample.astro"
+<Dropdown disabled {/* ... */}>
+  <!-- ... -->
+</Dropdown>
+```
+
+### 选项选项
+
+没错，您没看错。您也可以自定义选项。您可以单独禁用它们，将它们变成链接，甚至将它们的颜色更改为任何默认颜色：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Dropdown 
+        id='options-dropdown' 
+        options={[
+          { label: '默认', value: 'default', color: 'default' },
+          { label: '主要', value: 'primary', color: 'primary' },
+          { label: '成功', value: 'success', color: 'success' },
+          { label: '警告', value: 'warning', color: 'warning' },
+          { label: '危险', value: 'danger', color: 'danger' },
+          { label: '信息', value: 'info', color: 'info' },
+          { label: '单色', value: 'mono', color: 'mono' },
+          { label: '已禁用', value: 'disabled', disabled: true },
+          { label: '作为链接', value: 'custom-href', href: '/' },
+        ]}
+      >
+        <Button color='primary'>
+          自定义选项
+        </Button>
+      </Dropdown>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro ins={7-14} showLinenumbers title="DropdownOptionsExample.astro"
+    ---
+    import { Dropdown, Button } from 'studiocms:ui/components';
+    ---
+
+    <Dropdown 
+      id='dropdown' 
+      options={[
+        { label: '默认', value: 'default', color: 'default' },
+        { label: '主要', value: 'primary', color: 'primary' },
+        { label: '成功', value: 'success', color: 'success' },
+        { label: '警告', value: 'warning', color: 'warning' },
+        { label: '危险', value: 'danger', color: 'danger' },
+        { label: '信息', value: 'info', color: 'info' },
+        { label: '单色', value: 'mono', color: 'mono' },
+        { label: '已禁用', value: 'disabled', disabled: true },
+        { label: '作为链接', value: 'custom-href', href: '/' },
+      ]}
+    >
+      <Button color='primary'>
+        自定义选项
+      </Button>
+    </Dropdown>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { DropdownHelper } from 'studiocms:ui/components';
+
+    const dropdown = new DropdownHelper('dropdown');
+    ```
+  </TabItem>
+</Tabs>
+
+#### 图标
+
+下拉菜单项也支持图标。您可以将图标名称传递给选项对象：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Dropdown 
+        id='icons-dropdown' 
+        options={[
+          { label: '通知', value: 'notifications', icon: 'bell' },
+          { label: '设置', value: 'settings', icon: 'cog-6-tooth' },
+          { label: '个人资料', value: 'profile', icon: 'user' },
+        ]}
+      >
+        <Button color='primary'>
+          自定义图标
+        </Button>
+      </Dropdown>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro ins={7-14} showLinenumbers title="DropdownIconsExample.astro"
+    ---
+    import { Dropdown, Button } from 'studiocms:ui/components';
+    ---
+
+    <Dropdown 
+      id='dropdown' 
+      options={[
+        { label: '通知', value: 'notifications', icon: 'bell' },
+        { label: '设置', value: 'settings', icon: 'cog-6-tooth' },
+        { label: '个人资料', value: 'profile', icon: 'user' },
+      ]}
+    >
+      <Button color='primary'>
+        自定义图标
+      </Button>
+    </Dropdown>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { DropdownHelper } from 'studiocms:ui/components';
+
+    const dropdown = new DropdownHelper('dropdown');
+    ```
+  </TabItem>
+</Tabs>
+
+### 以编程方式控制下拉菜单
+
+您知道吗，在整个页面中，我们一直将 `DropdownHelper` 分配给一个变量？这是有原因的。DropdownHelper 允许您访问一些内置函数，用于以编程方式切换、显示和隐藏下拉菜单。您甚至可以注册一个回调，当下拉菜单的某个选项被点击时触发！
+
+```ts twoslash showLinenumbers title="Script Tag"
+// @noErrors
+import { DropdownHelper } from 'studiocms:ui/components';
+
+const dropdown = new DropdownHelper('dropdown');
+
+dropdown.registerClickCallback((value) => {
+  // `value` 将是您在下拉菜单包装器中为选项指定的值。
+  console.log(value);
+});
+
+// 您可以像这样切换下拉菜单：
+dropdown.toggle();
+
+// 除了切换，您也可以简单地显示或隐藏下拉菜单：
+dropdown.show();
+dropdown.hide();
+```
+
+{/* 所有辅助函数都在这里 🥲 */}
+<DropdownScript />

--- a/docs/src/content/docs/zh-cn/docs/components/footer.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/footer.mdx
@@ -1,0 +1,93 @@
+---
+title: "页脚"
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Footer } from 'studiocms:ui/components';
+
+一个具有大量自定义选项的页脚组件！
+
+:::note
+要查看此页脚的实际效果，请访问[落地页](/)！由于尺寸限制，我们无法在常规预览框中展示它。
+:::
+
+## 用法
+
+页脚组件有四种不同的自定义方式：
+
+1. `link` 属性，用于在各个类别中添加链接
+2. `copyright` 属性，用于显示版权或许可信息
+3. `brand` 插槽，可用于 logo 或不同的品牌文本
+4. `socials` 插槽，可用于社交图标（当然也可以是其他任何内容）
+
+```astro showLinenumbers title="FooterExample.astro"
+---
+import { Footer } from 'studiocms:ui/components';
+---
+
+<Footer
+  links={{
+    'Resources': [
+      { label: 'Docs', href: '/docs' },
+      { label: 'Support', href: '/support' },
+    ],
+    'Legal': [
+      { label: 'Privacy Policy', href: '/privacy' },
+      { label: 'Terms of Service', href: '/tos' },
+    ],
+  }}
+  copyright='MIT License © 2024 - Acme Inc.'
+>
+  <div slot="brand">
+    Acme, Inc.
+  </div>
+</Footer>
+```
+
+以下是我们在 StudioCMS UI 落地页上实现此页脚的示例：
+
+```astro showLinenumbers title="FooterExample.astro"
+---
+import { Footer } from 'studiocms:ui/components';
+// Different imports for icons & logos...
+---
+<!-- Other page content -->
+<Footer
+  links={{
+    'StudioCMS Ecosystem': [
+      { label: 'StudioCMS', href: 'https://studiocms.dev' },
+      { label: 'Apollo', href: 'https://github.com/withstudiocms/apollo' }
+    ],
+    'Resources': [
+      { label: 'Docs', href: '/docs' },
+    ],
+  }}
+  copyright='MIT License © 2024 - StudioCMS'
+>
+  <div slot='brand' class='footer-brand'>
+    <LogoAdaptive height={48} width={45.76} />
+    <span class='studiocms-footer-text'>
+      <span>StudioCMS</span>
+      <span>UI</span>
+    </span>
+  </div>
+  <div slot='socials' class='socials'>
+    <a href='https://github.com/withstudiocms'>
+      <GitHubLogo width={28} height={28} />
+    </a>
+    <a href='https://chat.studiocms.dev'>
+      <DiscordLogo width={32} height={32} />
+    </a>
+    <a href='https://patreon.com/studiocms'>
+      <PatreonLogo width={24} height={24} />
+    </a>
+    <a href='https://bsky.app/profile/studiocms.dev'>
+      <BlueSkyLogo width={24} height={24} />
+    </a>
+    <a href='https://twitter.com/withstudiocms'>
+      <TwitterLogo width={22} height={22} />
+    </a>
+  </div>
+</Footer>
+```

--- a/docs/src/content/docs/zh-cn/docs/components/group.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/group.mdx
@@ -1,0 +1,47 @@
+---
+title: 组
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+import { Group, Button, Badge } from 'studiocms:ui/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+
+组组件是一个容器组件，用于将其子元素分组在一起。
+它非常适合对按钮、徽章、输入框和其他组件进行分组，
+从而更轻松地管理它们的布局。它还会改变它们的样式，使它们看起来像是一个条形。
+
+组组件支持以下组件：
+
+- Button（按钮）
+- Badge（徽章）
+
+## 使用方法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Group>
+        <Button color="primary">按钮 1</Button>
+        <Button color="primary">按钮 2</Button>
+        <Button color="primary">按钮 3</Button>
+      </Group>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="GroupExample.astro"
+    ---
+    import { Group, Button } from 'studiocms:ui/components';
+    ---
+
+    <Group>
+      <Button color="primary">按钮 1</Button>
+      <Button color="primary">按钮 2</Button>
+      <Button color="primary">按钮 3</Button>
+    </Group>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/input.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/input.mdx
@@ -1,0 +1,98 @@
+---
+i18nReady: true
+title: 输入框
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Input } from 'studiocms:ui/components';
+
+一个简单的输入框组件，支持轻松设置标签和占位符。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Input label="标签" placeholder="占位符" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="InputExample.astro"
+    ---
+    import { Input } from 'studiocms:ui/components';
+    ---
+
+    <Input label='标签' placeholder='占位符' />
+    ```
+  </TabItem>
+</Tabs>
+
+### 不同类型的输入框
+
+您可以像平常一样设置输入框的类型。以下是一个密码输入框，展示如何实现：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Input label="标签" placeholder="占位符" type='password' />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "type='password'" showLinenumbers title="PasswordInputExample.astro"
+    ---
+    import { Input } from 'studiocms:ui/components';
+    ---
+
+    <Input label='标签' placeholder='占位符' type='password' />
+    ```
+  </TabItem>
+</Tabs>
+
+### 禁用状态
+
+您可以通过使用 `disabled` 属性来完全禁用输入框。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Input label="标签" placeholder="占位符" disabled />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "disabled" showLinenumbers title="DisabledInputExample.astro"
+    ---
+    import { Input } from 'studiocms:ui/components';
+    ---
+
+    <Input label='标签' placeholder='占位符' disabled />
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+输入框具有完整的表单支持。您可以根据需要使用 `isRequired` 和 `name` 属性。
+
+前者实现其所述功能，而后者设置 `name` 属性，以便您可以在例如提交返回的 `FormData` 中访问该输入框。以下是一个展示如何设置这两个属性的示例：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Input label="标签" placeholder="占位符" isRequired name="example-input" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "isRequired" "name='example-input'" showLinenumbers title="FormInputExample.astro"
+    ---
+    import { Input } from 'studiocms:ui/components';
+    ---
+
+    <Input label='标签' placeholder='占位符' isRequired name='example-input' />
+    ```
+  </TabItem>
+</Tabs>
+
+:::note
+如果未设置名称，则会为该组件生成一个随机名称。
+:::

--- a/docs/src/content/docs/zh-cn/docs/components/modal.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/modal.mdx
@@ -1,0 +1,314 @@
+---
+i18nReady: true
+title: 弹窗
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import ModalScript from '~/components/ModalScript.astro';
+import { Modal, Button, Row } from 'studiocms:ui/components';
+
+:::caution[需要辅助函数]
+此组件需要使用**辅助函数**。请务必仔细阅读文档，以了解如何使用它。
+:::
+
+一个弹窗组件，为您处理所有繁琐的细节，并额外支持编程式触发。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Modal id="usage-modal">
+        <h2 slot="header">标题内容</h2>
+        <div>弹窗内容</div>
+      </Modal>
+      <Button color="primary" id="usage-modal-trigger">
+        触发弹窗
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ModalExample.astro"
+    ---
+    import { Modal, Button } from 'studiocms:ui/components';
+    ---
+
+    <Modal id='modal'>
+      <h2 slot='header'>标题内容</h2>
+      <div>弹窗内容</div>
+    </Modal>
+    <Button color='primary' id='modal-trigger'>
+      触发弹窗
+    </Button>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { ModalHelper } from 'studiocms:ui/components';
+
+    const modal = new ModalHelper('modal', 'modal-trigger');
+    ```
+  </TabItem>
+</Tabs>
+
+### 尺寸
+
+您可以将弹窗的尺寸更改为三种预设之一。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Modal id="sizes-modal-sm" size="sm">
+        <h2 slot="header">小型弹窗</h2>
+        <div>
+          Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+          nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+          aliquam nam consectetur dolorum et unde optio At delectus alias.
+        </div>
+      </Modal>
+      <Modal id="sizes-modal-md">
+        <h2 slot="header">中等内容</h2>
+        <div>
+          Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+          nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+          aliquam nam consectetur dolorum et unde optio At delectus alias.
+        </div>
+      </Modal>
+      <Modal id="sizes-modal-lg" size="lg">
+        <h2 slot="header">大型内容</h2>
+        <div>
+          Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+          nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+          aliquam nam consectetur dolorum et unde optio At delectus alias.
+        </div>
+      </Modal>
+
+      <Row alignCenter>
+        <Button color="primary" id="sm-modal-trigger">
+          小型
+        </Button>
+        <Button color="primary" id="md-modal-trigger">
+          中型
+        </Button>
+        <Button color="primary" id="lg-modal-trigger">
+          大型
+        </Button>
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /size='[a-z]+'/ showLinenumbers title="ModalSizesExample.astro"
+    ---
+    import { Modal, Button } from 'studiocms:ui/components';
+    ---
+
+    <Modal id='modal' size='sm'>
+      <h2 slot='header'>小型弹窗</h2>
+      <div>
+        Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+        nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+        aliquam nam consectetur dolorum et unde optio At delectus alias.
+      </div>
+    </Modal>
+    <Button color='primary' id='modal-trigger'>
+      小型
+    </Button>
+
+    <!-- 为简洁起见，省略了其他弹窗和触发器 -->
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { ModalHelper } from 'studiocms:ui/components';
+
+    const modal = new ModalHelper('modal', 'modal-trigger');
+    ```
+  </TabItem>
+</Tabs>
+
+### 可关闭性
+
+您可以通过 `dismissable` 属性更改弹窗是否可以通过点击其外部来关闭。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Modal id="dismissable-modal" dismissable={false}>
+        <h2 slot="header">不可关闭</h2>
+        <div>
+          Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+          nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+          aliquam nam consectetur dolorum et unde optio At delectus alias.
+        </div>
+      </Modal>
+
+      <Button color="primary" id="dismissable-modal-trigger">
+        不可关闭
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "dismissable={false}" showLinenumbers title="ModalDismissableExample.astro"
+    ---
+    import { Modal, Button } from 'studiocms:ui/components';
+    ---
+
+    <Modal id='modal' dismissable={false}>
+      <h2 slot='header'>不可关闭</h2>
+      <div>
+        Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+        nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+        aliquam nam consectetur dolorum et unde optio At delectus alias.
+      </div>
+    </Modal>
+    <Button color='primary' id='modal-trigger'>
+      不可关闭
+    </Button>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { ModalHelper } from 'studiocms:ui/components';
+
+    const modal = new ModalHelper('modal', 'modal-trigger');
+    ```
+  </TabItem>
+</Tabs>
+
+如果弹窗有按钮（见下文），右上角的 `x` 按钮也将消失。
+
+### 按钮
+
+弹窗支持“取消”和“确认”两种按钮。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Modal id="buttons-modal" cancelButton="取消" actionButton="确认" class="not-content">
+        <h2 slot="header">按钮</h2>
+        <div>
+          Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+          nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+          aliquam nam consectetur dolorum et unde optio At delectus alias.
+        </div>
+      </Modal>
+
+      <Button color="primary" id="buttons-modal-trigger">
+        按钮
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "cancelButton='Cancel' actionButton='Confirm'" showLinenumbers title="ModalButtonsExample.astro"
+    ---
+    import { Modal, Button } from 'studiocms:ui/components';
+    ---
+
+    <Modal id='modal' cancelButton='取消' actionButton='确认'>
+      <h2 slot='header'>按钮</h2>
+      <div>
+        Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+        nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+        aliquam nam consectetur dolorum et unde optio At delectus alias.
+      </div>
+    </Modal>
+    <Button color='primary' id='modal-trigger'>
+      按钮
+    </Button>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { ModalHelper } from 'studiocms:ui/components';
+
+    const modal = new ModalHelper('modal', 'modal-trigger');
+    ```
+  </TabItem>
+</Tabs>
+
+如果您愿意，可以将定义了 `label` 和 `color` 键的对象传递给属性，而不是将标签作为字符串传递，从而更改按钮的外观：
+
+```astro "cancelButton={{ label: 'Cancel', color: 'default' }} actionButton={{ label: 'Confirm', color: 'danger' }}" showLinenumbers title="ModalButtonsExample.astro"
+---
+import { Modal, Button } from 'studiocms:ui/components';
+---
+
+<Modal
+  id='modal'
+  cancelButton={{ label: '取消', color: 'default' }}
+  actionButton={{ label: '确认', color: 'danger' }}
+>
+  <h2 slot='header'>按钮</h2>
+  <div>
+    Lorem ipsum dolor sit amet. Est corporis rerum est reprehenderit 
+    nesciunt qui quibusdam quam non totam quia. Et porro unde et rerum 
+    aliquam nam consectetur dolorum et unde optio At delectus alias.
+  </div>
+</Modal>
+<Button color='primary' id='modal-trigger'>
+  按钮
+</Button>
+```
+
+### 注册回调
+
+如果您想根据点击哪个按钮来实现功能，可以分别为它们注册回调。
+
+```ts twoslash ins={5-7,9-11} showLinenumbers title="Script Tag"
+// @noErrors
+import { ModalHelper } from 'studiocms:ui/components';
+
+const modal = new ModalHelper('modal', 'modal-trigger');
+
+modal.registerCancelCallback(() => {
+  // 您的逻辑写在这里
+});
+
+modal.registerConfirmCallback(() => {
+  // 您的逻辑写在这里
+});
+```
+
+### 表单支持
+
+您可以通过提供 `isForm` 属性将弹窗变为表单！这会将“取消”按钮变为重置按钮，将“确认”按钮变为提交按钮。
+这只会改变它们的类型，而不会改变它们的文本。
+
+通过使用 `registerConfirmCallback` 函数，您可以在点击“确认”按钮后获取 `FormData`。弹窗中的任何输入都将包含在内。
+
+```ts twoslash "formData" showLinenumbers title="Script Tag"
+// @noErrors
+import { ModalHelper } from 'studiocms:ui/components';
+
+const modal = new ModalHelper('modal', 'modal-trigger');
+
+modal.registerConfirmCallback((formData) => {
+  // 您的逻辑写在这里
+});
+```
+
+### 绑定触发器
+
+您可以通过结合使用元素的 ID 和 `bindTrigger` 函数为弹窗添加多个触发器。
+
+```ts twoslash ins={4-5} showLinenumbers title="Script Tag"
+// @noErrors
+import { ModalHelper } from 'studiocms:ui/components';
+
+const modal = new ModalHelper('modal', 'modal-trigger');
+modal.bindTrigger('modal-trigger-two');
+modal.bindTrigger('modal-trigger-three');
+```
+
+### 编程控制弹窗
+
+与[下拉菜单](/customizing/studiocms-ui/components/dropdown)类似，弹窗也可以通过编程方式显示和隐藏：
+
+```ts twoslash ins={5-6} showLinenumbers title="Script Tag"
+// @noErrors
+import { ModalHelper } from 'studiocms:ui/components';
+
+const modal = new ModalHelper('modal', 'modal-trigger');
+
+modal.show();
+modal.hide();
+```
+
+<ModalScript />

--- a/docs/src/content/docs/zh-cn/docs/components/progress.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/progress.mdx
@@ -1,0 +1,112 @@
+---
+title: 进度条
+sidebar:
+  badge:
+    text: New!
+    variant: success
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import ProgressScript from '~/components/ProgressScript.astro';
+import { Progress, ProgressHelper } from 'studiocms:ui/components';
+
+:::caution[需要辅助函数]
+此组件需要使用**辅助函数**。请务必仔细阅读文档，以了解如何使用它。
+:::
+
+进度条，用于显示任务的进度。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Progress id="prog-1" max={100} value={50} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ProgressExample.astro"
+    ---
+    import { Progress } from 'studiocms:ui/components';
+    ---
+
+    <Progress id="progress" max={100} value={50} />
+    ```
+  </TabItem>
+</Tabs>
+
+### Value 和 Max
+
+与原生 HTML `<progress>` 元素类似，`Progress` 组件接受两个属性：`value` 和 `max`。`value` 属性表示当前进度，而 `max` 属性表示进度条的最大值。
+
+可以使用 `ProgressHelper` 在组件初始化后调整 value 和 max，它以进度条的 ID 作为唯一参数：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Progress id="prog-2" max={100} value={50} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ProgressExample.astro"
+    ---
+    import { Progress } from 'studiocms:ui/components';
+    ---
+
+    <Progress id="progress" max={100} value={50} />
+    <script>
+      import { ProgressHelper } from 'studiocms:ui/components';
+
+      const progress = new ProgressHelper('progress');
+      progress.setValue(75);
+      progress.setMax(150);
+      
+      // 您可以获取进度条的 value、max 和 percentage
+      progress.getValue(); // 75
+      progress.getMax(); // 150
+      progress.getPercentage(); // 50
+    </script>
+    ```
+  </TabItem>
+</Tabs>
+
+### 颜色
+
+通过将 `color` 属性设置为以下值之一，可以为进度组件使用主题中所有可用的颜色进行着色：
+
+- `primary`
+- `success`
+- `warning`
+- `danger`
+- `info`
+- `monochrome`
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Progress id="prog-3" max={100} value={50} color="primary" />
+      <Progress id="prog-3" max={100} value={50} color="success" />
+      <Progress id="prog-4" max={100} value={50} color="warning" />
+      <Progress id="prog-3" max={100} value={50} color="danger" />
+      <Progress id="prog-4" max={100} value={50} color="info" />
+      <Progress id="prog-3" max={100} value={50} color="monochrome" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ProgressExample.astro"
+    ---
+    import { Progress } from 'studiocms:ui/components';
+    ---
+
+    <Progress id="progress-1" max={100} value={50} color="primary" />
+    <Progress id="progress-2" max={100} value={50} color="success" />
+    <Progress id="progress-3" max={100} value={50} color="warning" />
+    <Progress id="progress-4" max={100} value={50} color="danger" />
+    <Progress id="progress-5" max={100} value={50} color="info" />
+    <Progress id="progress-6" max={100} value={50} color="monochrome" />
+    ```
+  </TabItem>
+</Tabs>
+
+<ProgressScript />

--- a/docs/src/content/docs/zh-cn/docs/components/radio-group.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/radio-group.mdx
@@ -1,0 +1,184 @@
+---
+i18nReady: true
+title: 单选组
+sidebar:
+  badge:
+    text: New Colors！
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { RadioGroup, Row } from 'studiocms:ui/components';
+
+一个支持大小和颜色的自定义单选按钮组组件。兼容表单。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <RadioGroup label="标签" options={[{label: '选项 1', value: 'opt-1'}, {label: '选项 2', value: 'opt-2'}]} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="RadioGroupExample.astro"
+    ---
+    import { RadioGroup } from 'studiocms:ui/components';
+    ---
+
+    <RadioGroup 
+      label='标签'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' }
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 方向
+
+你可以通过使用 `horizontal` 属性将单选按钮组更改为水平显示：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <RadioGroup label="标签" horizontal options={[{label: '选项 1', value: 'opt-1-h'}, {label: '选项 2', value: 'opt-2-h'}]} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "horizontal" showLinenumbers title="RadioGroupHorizontalExample.astro"
+    ---
+    import { RadioGroup } from 'studiocms:ui/components';
+    ---
+
+    <RadioGroup 
+      label='标签'
+      horizontal
+      options={[
+        { label: '选项 1', value: 'opt-1-h' },
+        { label: '选项 2', value: 'opt-2-h' }
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 默认值
+
+你可以通过 `defaultValue` 属性设置一个默认选中的选项。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <RadioGroup label="默认选中" defaultValue='opt-1-def' options={[{ label: '选项 1', value: 'opt-1-def' }]} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "defaultValue='opt-1'" showLinenumbers title="RadioGroupDefaultValueExample.astro"
+    ---
+    import { RadioGroup } from 'studiocms:ui/components';
+    ---
+
+    <RadioGroup 
+      label='默认选中'
+      defaultValue='opt-1'
+      options={[
+        { label: '选项 1', value: 'opt-1' }
+      ]} 
+    />
+    <!-- 为简洁起见省略了其他颜色 -->
+    ```
+  </TabItem>
+</Tabs>
+
+### 颜色
+
+单选按钮组组件支持所有默认配色。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>  
+      <RadioGroup label="主要" defaultValue='opt-1-p' options={[{ label: '选项 1', value: 'opt-1-p' }]} color='primary' />
+      <RadioGroup label="成功" defaultValue='opt-1-s' options={[{ label: '选项 1', value: 'opt-1-s' }]} color='success' />
+      <RadioGroup label="警告" defaultValue='opt-1-w' options={[{ label: '选项 1', value: 'opt-1-w' }]} color='warning' />
+      <RadioGroup label="危险" defaultValue='opt-1-da' options={[{ label: '选项 1', value: 'opt-1-da' }]} color='danger' />
+      <RadioGroup label="信息" defaultValue='opt-1-info' options={[{ label: '选项 1', value: 'opt-1-info' }]} color='info' />
+      <RadioGroup label="单色" defaultValue='opt-1-mono' options={[{ label: '选项 1', value: 'opt-1-mono' }]} color='mono' />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "color='primary'" showLinenumbers title="RadioGroupColorExample.astro"
+    ---
+    import { RadioGroup } from 'studiocms:ui/components';
+    ---
+
+    <RadioGroup 
+      label='默认选中'
+      defaultValue='opt-1'
+      options={[
+        { label: '选项 1', value: 'opt-1' }
+      ]}
+      color='primary'
+    />
+    <!-- 为简洁起见省略了其他颜色 -->
+    ```
+  </TabItem>
+</Tabs>
+
+### 禁用
+
+你可以禁用整个单选按钮组（通过传递 `disabled` 属性）或通过选项禁用单个选项。下面的示例展示了如何执行后者：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <RadioGroup label="禁用一个选项" options={[{ label: '选项 1', value: 'opt-1-dis' }, { label: '选项 2', value: 'opt-2-dis', disabled: true }]} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "disabled: true" showLinenumbers title="RadioGroupDisabledExample.astro"
+    ---
+    import { RadioGroup } from 'studiocms:ui/components';
+    ---
+
+    <RadioGroup 
+      label='默认'
+      options={[
+        { label: '选项 1', value: 'opt-1', disabled: true },
+        { label: '选项 1', value: 'opt-2' }
+      ]}
+      color='primary' 
+    />
+    <!-- 为简洁起见省略了其他颜色 -->
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+输入控件具有完整的表单支持。你可以根据需要使用 `isRequired` 和 `name` 属性。
+
+前者如其名所示，后者设置 `name` 属性，以便你可以访问输入，例如，在提交返回的 `FormData` 中。以下是一个展示如何设置这两个属性的示例：
+
+```astro "isRequired" "name='required-radio'" showLinenumbers title="RadioGroupFormExample.astro"
+---
+import { RadioGroup } from 'studiocms:ui/components';
+---
+
+<RadioGroup 
+  label='必填 & 自定义名称'
+  isRequired
+  name='required-radio'
+  options={[
+    { label: '选项 1', value: 'opt-1' },
+    { label: '选项 2', value: 'opt-2' }
+  ]}
+/>
+```
+
+:::note
+如果未设置名称，则会为该组件生成一个随机名称。
+:::

--- a/docs/src/content/docs/zh-cn/docs/components/row.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/row.mdx
@@ -1,0 +1,91 @@
+---
+i18nReady: true
+title: 行（Row）
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Row } from 'studiocms:ui/components';
+
+一个小的 `flex: row` 包装器。将所有 flex 的怪异之处抽象为一个组件。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Row>
+        <span>行项目 1</span>
+        <span>行项目 2</span>
+        <span>行项目 3</span>
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="RowExample.astro"
+    ---
+    import { Row } from 'studiocms:ui/components';
+    ---
+
+    <Row>
+      <span>行项目 1</span>
+      <span>行项目 2</span>
+      <span>行项目 3</span>
+    </Row>
+    ```
+  </TabItem>
+</Tabs>
+
+### `align-items: center`
+
+您可以传递 `alignCenter` 属性以向该行添加 `align-items: center` CSS 属性。
+
+```astro "alignCenter" showLinenumbers title="RowAlignCenterExample.astro"
+---
+import { Row } from 'studiocms:ui/components';
+---
+
+<Row alignCenter>
+  <!-- 内容 -->
+</Row>
+```
+
+### 间距大小
+
+您可以通过 `gapSize` 属性更改行的间距大小，该属性可以设置为 `sm`、`md` 或 `lg` 之一。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard vertical gapSize="lg">
+      <Row gapSize="sm">
+        <span>小行</span>
+        <span>小行</span>
+        <span>小行</span>
+      </Row>
+      <Row gapSize="md">
+        <span>中行</span>
+        <span>中行</span>
+        <span>中行</span>
+      </Row>
+      <Row gapSize="lg">
+        <span>大行</span>
+        <span>大行</span>
+        <span>大行</span>
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "gapSize='sm'" showLinenumbers title="RowGapSizeExample.astro"
+    ---
+    import { Row } from 'studiocms:ui/components';
+    ---
+
+    <Row gapSize='sm'>
+      <span>小行</span>
+      <span>小行</span>
+      <span>小行</span>
+    </Row>
+    <!-- 为简洁起见，省略了其他示例 -->
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/select-searchable.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/select-searchable.mdx
@@ -1,0 +1,300 @@
+---
+i18nReady: true
+title: 选择（可搜索）
+sidebar:
+  badge:
+    text: Updated!
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { SearchSelect } from 'studiocms:ui/components';
+
+`<Select />` 元素的一种变体，支持方向键和筛选。
+
+**可以直接用作替代品。**
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <SearchSelect
+        label='选择元素'
+        options={[
+          { label: "选项 1", value: "opt-1-1" },
+          { label: "选项 2", value: "opt-2-1" },
+          { label: "选项 3", value: "opt-3-1" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="SearchSelectExample.astro"
+    ---
+    import { SearchSelect } from 'studiocms:ui/components';
+    ---
+
+    <SearchSelect
+      label='可搜索选择元素'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 默认值
+
+您可以使用 `defaultValue` 属性设置默认值：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <SearchSelect
+        label='可搜索选择元素'
+        defaultValue='opt-1-1'
+        options={[
+          { label: "选项 1", value: "opt-1-1" },
+          { label: "选项 2", value: "opt-2-1" },
+          { label: "选项 3", value: "opt-3-1" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "defaultValue='opt-1'" showLinenumbers title="SearchSelectDefaultValueExample.astro"
+    ---
+    import { SearchSelect } from 'studiocms:ui/components';
+    ---
+
+    <SearchSelect
+      label='可搜索选择元素'
+      defaultValue='opt-1'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+您可以使用 `isRequired` 属性将选择输入标记为必填。这还会在标签中添加红色的 `*`。
+
+如果您稍后需要访问元素的值，可以传递 `name` 属性。它随后将出现在您构建的任何 FormData 中。如果未设置名称，则会为组件生成一个随机名称。
+
+此外，您可以使用 `disabled` 属性禁用整个选择输入，或者通过在要禁用的选项中添加 `disabled: true` 来禁用单个选项：
+
+```astro ins={7-9,16} showLinenumbers title="SearchSelectFormExample.astro"
+---
+import { SearchSelect } from 'studiocms:ui/components';
+---
+
+<SearchSelect
+  label='可搜索选择元素'
+  defaultValue='opt-1'
+  isRequired
+  disabled
+  name='searchable-select-element'
+  options={[
+    // ...
+    { 
+      label: '选项 X',
+      value: 'opt-x',
+      disabled: true
+    },
+    // ...
+  ]}
+/>
+```
+
+### 全宽
+
+通常，输入框具有最小宽度并根据需要进行扩展。您可以通过将 `fullWidth` 属性设置为 true 来强制其占满父容器的整个宽度：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <SearchSelect
+        label='可搜索选择元素'
+        fullWidth
+        options={[
+          { label: "选项 1", value: "f-opt-1-1" },
+          { label: "选项 2", value: "f-opt-1-2" },
+          { label: "选项 3", value: "f-opt-1-3" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "fillWidth" showLinenumbers title="FullWidthSearchSelectExample.astro"
+    ---
+    import { SearchSelect } from 'studiocms:ui/components';
+    ---
+
+    <SearchSelect
+      label='可搜索选择元素'
+      fullWidth
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 占位符
+
+您可以通过传递 `placeholder` 属性来调整选择器中显示的占位符：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <SearchSelect
+        label='可搜索选择元素'
+        placeholder="自定义占位符"
+        options={[
+          { label: "选项 1", value: "f-opt-1-p" },
+          { label: "选项 2", value: "f-opt-2-p" },
+          { label: "选项 3", value: "f-opt-3-p" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "placeholder='Custom Placeholder'" showLinenumbers title="SearchSelectPlaceholderExample.astro"
+    ---
+    import { SearchSelect } from 'studiocms:ui/components';
+    ---
+
+    <SearchSelect
+      label='可搜索选择元素'
+      placeholder='自定义占位符'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 多选
+
+您可以通过将 `multiple` 属性设置为 `true` 来选择多个选项：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <SearchSelect
+        label='可搜索选择元素'
+        multiple
+        placeholder='选择多个选项'
+        defaultValue={[
+          'opt-1-mult1',
+          'opt-2-mult1',
+          'opt-3-mult1',
+        ]}
+        options={[
+          { label: "选项 1", value: "opt-1-mult1" },
+          { label: "选项 2", value: "opt-2-mult1" },
+          { label: "选项 3", value: "opt-3-mult1" },
+          { label: "选项 4", value: "opt-4-mult1" },
+          { label: "选项 5", value: "opt-5-mult1" },
+          { label: "选项 6", value: "opt-6-mult1" },
+          { label: "选项 7", value: "opt-7-mult1" },
+          { label: "选项 8", value: "opt-8-mult1" },
+          { label: "选项 9", value: "opt-9-mult1" },
+          { label: "选项 10", value: "opt-10-mult1" },
+          { label: "选项 11", value: "opt-11-mult1" },
+          { label: "选项 12", value: "opt-12-mult1" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "multiple" showLinenumbers title="SearchSelectMultipleExample.astro"
+    ---
+    import { SearchSelect } from 'studiocms:ui/components';
+    ---
+
+    <SearchSelect
+      label='可搜索选择元素'
+      multiple
+      defaultValue={[
+        'opt-1-mult1',
+        'opt-2-mult1',
+        'opt-3-mult1',
+      ]}
+      options={[
+        { label: "选项 1", value: "opt-1-mult1" },
+        { label: "选项 2", value: "opt-2-mult1" },
+        { label: "选项 3", value: "opt-3-mult1" },
+        { label: "选项 4", value: "opt-4-mult1" },
+        { label: "选项 5", value: "opt-5-mult1" },
+        { label: "选项 6", value: "opt-6-mult1" },
+        { label: "选项 7", value: "opt-7-mult1" },
+        { label: "选项 8", value: "opt-8-mult1" },
+        { label: "选项 9", value: "opt-9-mult1" },
+        { label: "选项 10", value: "opt-10-mult1" },
+        { label: "选项 11", value: "opt-11-mult1" },
+        { label: "选项 12", value: "opt-12-mult1" },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 最大选择数
+
+您可以使用 `max` 属性设置可选择的最大选项数：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <SearchSelect
+        label='可搜索选择元素'
+        multiple
+        max={3}
+        options={[
+          { label: "选项 1", value: "opt-1-mult2" },
+          { label: "选项 2", value: "opt-2-mult2" },
+          { label: "选项 3", value: "opt-3-mult2" },
+          { label: "选项 4", value: "opt-4-mult2" },
+          { label: "选项 5", value: "opt-5-mult2" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "max={3}" showLinenumbers title="SearchSelectMultipleMaxExample.astro"
+    ---
+    import { SearchSelect } from 'studiocms:ui/components';
+    ---
+
+    <SearchSelect
+      label='可搜索选择元素'
+      multiple
+      max={3}
+      options={[
+        { label: "选项 1", value: "opt-1-mult2" },
+        { label: "选项 2", value: "opt-2-mult2" },
+        { label: "选项 3", value: "opt-3-mult2" },
+        { label: "选项 4", value: "opt-4-mult2" },
+        { label: "选项 5", value: "opt-5-mult2" },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/select.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/select.mdx
@@ -1,0 +1,297 @@
+---
+i18nReady: true
+title: 选择
+sidebar:
+  badge:
+    text: Updated!
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Select } from 'studiocms:ui/components';
+
+一个开箱即用的自定义选择元素。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Select
+        label='选择元素'
+        options={[
+          { label: "选项 1", value: "opt-1-1" },
+          { label: "选项 2", value: "opt-2-1" },
+          { label: "选项 3", value: "opt-3-1" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="SelectExample.astro"
+    ---
+    import { Select } from 'studiocms:ui/components';
+    ---
+
+    <Select
+      label='选择元素'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 默认值
+
+您可以使用 `defaultValue` 属性设置默认值：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Select
+        label='选择元素'
+        defaultValue='opt-1-1'
+        options={[
+          { label: "选项 1", value: "opt-1-1" },
+          { label: "选项 2", value: "opt-2-1" },
+          { label: "选项 3", value: "opt-3-1" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "defaultValue='opt-1'" showLinenumbers title="SelectDefaultValueExample.astro"
+    ---
+    import { Select } from 'studiocms:ui/components';
+    ---
+
+    <Select
+      label='选择元素'
+      defaultValue='opt-1'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+您可以使用 `isRequired` 属性将选择输入标记为必填。这还会在标签上添加一个红色的 `*`。
+
+如果您稍后需要访问元素的值，可以传递 `name` 属性。它随后会出现在您构建的任何 FormData 中。如果未设置名称，则会为该组件生成一个随机名称。
+
+此外，您可以使用 `disabled` 属性禁用整个选择输入，也可以通过向要禁用的选项添加 `disabled: true` 来禁用单个选项：
+
+```astro ins={7-9,16} showLinenumbers title="SelectFormExample.astro"
+---
+import { Select } from 'studiocms:ui/components';
+---
+
+<Select
+  label='选择元素'
+  defaultValue='opt-1'
+  isRequired
+  disabled
+  name='select-element'
+  options={[
+    // ...
+    { 
+      label: '选项 X', 
+      value: 'opt-x', 
+      disabled: true
+    },
+    // ...
+  ]}
+/>
+```
+
+### 全宽
+
+通常，输入具有最小宽度并根据需要扩展。您可以通过将 `fullWidth` 属性设置为 true 来强制其占据父容器的整个宽度：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Select
+        label='选择元素'
+        fullWidth
+        options={[
+          { label: "选项 1", value: "f-opt-1-1" },
+          { label: "选项 2", value: "f-opt-1-2" },
+          { label: "选项 3", value: "f-opt-1-3" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "fullWidth" showLinenumbers title="SelectFullWidthExample.astro"
+    ---
+    import { Select } from 'studiocms:ui/components';
+    ---
+
+    <Select
+      label='选择元素'
+      fullWidth
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 占位符
+
+您可以通过传递 `placeholder` 属性来调整选择中显示的占位符：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Select
+        label='选择元素'
+        placeholder="自定义占位符"
+        options={[
+          { label: "选项 1", value: "f-opt-1-p" },
+          { label: "选项 2", value: "f-opt-2-p" },
+          { label: "选项 3", value: "f-opt-3-p" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "placeholder='自定义占位符'" showLinenumbers title="SelectPlaceholderExample.astro"
+    ---
+    import { Select } from 'studiocms:ui/components';
+    ---
+
+    <Select
+      label='选择元素'
+      placeholder='自定义占位符'
+      options={[
+        { label: '选项 1', value: 'opt-1' },
+        { label: '选项 2', value: 'opt-2' },
+        { label: '选项 3', value: 'opt-3' },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 多个选项
+
+您可以通过将 `multiple` 属性设置为 `true` 来选择多个选项：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Select
+        label='选择元素'
+        multiple
+        defaultValue={[
+          'opt-1-mult1',
+          'opt-2-mult1',
+          'opt-3-mult1',
+        ]}
+        options={[
+          { label: "选项 1", value: "opt-1-mult1" },
+          { label: "选项 2", value: "opt-2-mult1" },
+          { label: "选项 3", value: "opt-3-mult1" },
+          { label: "选项 4", value: "opt-4-mult1" },
+          { label: "选项 5", value: "opt-5-mult1" },
+          { label: "选项 6", value: "opt-6-mult1" },
+          { label: "选项 7", value: "opt-7-mult1" },
+          { label: "选项 8", value: "opt-8-mult1" },
+          { label: "选项 9", value: "opt-9-mult1" },
+          { label: "选项 10", value: "opt-10-mult1" },
+          { label: "选项 11", value: "opt-11-mult1" },
+          { label: "选项 12", value: "opt-12-mult1" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "multiple" showLinenumbers title="SelectMultipleExample.astro"
+    ---
+    import { Select } from 'studiocms:ui/components';
+    ---
+
+    <Select
+      label='选择元素'
+      multiple
+      defaultValue={[
+        'opt-1-mult1',
+        'opt-2-mult1',
+        'opt-3-mult1',
+      ]}
+      options={[
+        { label: "选项 1", value: "opt-1-mult1" },
+        { label: "选项 2", value: "opt-2-mult1" },
+        { label: "选项 3", value: "opt-3-mult1" },
+        { label: "选项 4", value: "opt-4-mult1" },
+        { label: "选项 5", value: "opt-5-mult1" },
+        { label: "选项 6", value: "opt-6-mult1" },
+        { label: "选项 7", value: "opt-7-mult1" },
+        { label: "选项 8", value: "opt-8-mult1" },
+        { label: "选项 9", value: "opt-9-mult1" },
+        { label: "选项 10", value: "opt-10-mult1" },
+        { label: "选项 11", value: "opt-11-mult1" },
+        { label: "选项 12", value: "opt-12-mult1" },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+### 最大选项数
+
+您可以使用 `max` 属性设置可以选择的最大选项数：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Select
+        label='选择元素'
+        multiple
+        max={3}
+        options={[
+          { label: "选项 1", value: "opt-1-mult2" },
+          { label: "选项 2", value: "opt-2-mult2" },
+          { label: "选项 3", value: "opt-3-mult2" },
+          { label: "选项 4", value: "opt-4-mult2" },
+          { label: "选项 5", value: "opt-5-mult2" },
+        ]}
+      />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "max={3}" showLinenumbers title="SelectMultipleMaxExample.astro"
+    ---
+    import { Select } from 'studiocms:ui/components';
+    ---
+
+    <Select
+      label='选择元素'
+      multiple
+      max={3}
+      options={[
+        { label: "选项 1", value: "opt-1-mult2" },
+        { label: "选项 2", value: "opt-2-mult2" },
+        { label: "选项 3", value: "opt-3-mult2" },
+        { label: "选项 4", value: "opt-4-mult2" },
+        { label: "选项 5", value: "opt-5-mult2" },
+      ]}
+    />
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/tabs.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/tabs.mdx
@@ -1,0 +1,285 @@
+---
+title: "标签页"
+sidebar:
+  badge:
+    text: New Colors!
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs as SuiTabs, TabItem as SuiTabItem, Card, Divider } from 'studiocms:ui/components';
+
+import PreviewCard from '~/components/PreviewCard.astro';
+
+您可以在 [StudioCMS UI 落地页](https://ui.studiocms.dev) 上看到的标签页，现在作为组件提供！
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard fullWidth>
+      <SuiTabs>
+        <SuiTabItem label="标签 #1">
+          <Card fullWidth>
+            内容 #1
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #2">
+          <Card fullWidth>
+            内容 #2
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #3">
+          <Card fullWidth>
+            内容 #3
+          </Card>
+        </SuiTabItem>
+      </SuiTabs>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="TabsExample.astro"
+    ---
+    import { Tabs, TabItem, Card } from 'studiocms:ui/components';
+    ---
+
+    <Tabs>
+      <TabItem label='标签 #1'>
+        <Card fullWidth>
+          内容 #1
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #2'>
+        <Card fullWidth>
+          内容 #2
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #3'>
+        <Card fullWidth>
+          内容 #3
+        </Card>
+      </TabItem>
+    </Tabs>
+    ```
+  </TabItem>
+</Tabs>
+
+### 自定义标签页
+
+您可以添加图标，甚至更改标签页的颜色：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard fullWidth>
+      <SuiTabs>
+        <SuiTabItem label="黄色 + 星星" icon="star" color="warning">
+          <Card fullWidth>
+            黄色 + 星星
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="绿色 + 箭头" icon="arrows-right-left" color="success">
+          <Card fullWidth>
+            绿色 + 箭头
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="红色 + 铃铛" icon="bell" color="danger">
+          <Card fullWidth>
+            红色 + 铃铛
+          </Card>
+        </SuiTabItem>
+      </SuiTabs>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /icon='[A-Za-z-]+' color='[A-Za-z]+'/ showLinenumbers title="TabsCustomizationExample.astro"
+    ---
+    import { Tabs, TabItem, Card } from 'studiocms:ui/components';
+    ---
+
+    <Tabs>
+      <TabItem label='黄色 + 星星' icon='star' color='warning'>
+        <Card fullWidth>
+          黄色 + 星星
+        </Card>
+      </TabItem>
+      <TabItem label='绿色 + 箭头' icon='arrows-right-left' color='success'>
+        <Card fullWidth>
+          绿色 + 箭头
+        </Card>
+      </TabItem>
+      <TabItem label='红色 + 铃铛' icon='bell' color='danger'>
+        <Card fullWidth>
+          红色 + 铃铛
+        </Card>
+      </TabItem>
+    </Tabs>
+    ```
+  </TabItem>
+</Tabs>
+
+### 变体
+
+对于那些不喜欢默认标签页外观的用户，您可以将 `variant` 属性更改为 `starlight`。这将赋予标签页与 Starlight 相同的外观，也就是您在本页预览卡片上看到的那种外观。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard fullWidth>
+      <SuiTabs variant="starlight">
+        <SuiTabItem label="标签 #1">
+          <Card fullWidth>
+            内容 #1
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #2">
+          <Card fullWidth>
+            内容 #2
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #3">
+          <Card fullWidth>
+            内容 #3
+          </Card>
+        </SuiTabItem>
+      </SuiTabs>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "variant='starlight'" showLinenumbers title="TabsVariantsExample.astro"
+    ---
+    import { Tabs, TabItem, Card } from 'studiocms:ui/components';
+    ---
+
+    <Tabs variant='starlight'>
+      <TabItem label='标签 #1'>
+        <Card fullWidth>
+          内容 #1
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #2'>
+        <Card fullWidth>
+          内容 #2
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #3'>
+        <Card fullWidth>
+          内容 #3
+        </Card>
+      </TabItem>
+    </Tabs>
+    ```
+  </TabItem>
+</Tabs>
+
+### 对齐
+
+在某些情况下，您可能想要更改标签页的对齐方式。您可以通过将 `align` 属性设置为 `left`（左对齐）、`center`（居中）或 `right`（右对齐）来实现这一点，默认为左对齐。下面是一个标签页右对齐的示例：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard fullWidth>
+      <SuiTabs align="right">
+        <SuiTabItem label="标签 #1">
+          <Card fullWidth>
+            内容 #1
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #2">
+          <Card fullWidth>
+            内容 #2
+          </Card>
+        </SuiTabItem>
+      </SuiTabs>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "align='right'" showLinenumbers title="TabsAlignmentExample.astro"
+    ---
+    import { Tabs, TabItem, Card } from 'studiocms:ui/components';
+    ---
+
+    <Tabs align='right'>
+      <TabItem label='标签 #1'>
+        <Card fullWidth>
+          内容 #1
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #2'>
+        <Card fullWidth>
+          内容 #2
+        </Card>
+      </TabItem>
+    </Tabs>
+    ```
+  </TabItem>
+</Tabs>
+
+这甚至适用于 `starlight` 变体！
+
+### 同步与存储
+
+为了保存用户的选择，甚至在多个不同的标签页容器之间同步它们，您可以设置一个 `syncKey`。默认情况下，为了符合 GDPR 指南，此值将存储在 sessionStorage 中，但是如果您愿意，您可以将 `storage` 属性设置为 `persistent` 以将值存储在 localStorage 中。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard fullWidth vertical>
+      <SuiTabs syncKey="sync-example">
+        <SuiTabItem label="标签 #1 (同步 1)" icon="bolt">
+          <Card fullWidth>
+            标签内容 #1 (同步 1)
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #2 (同步 2)" icon="bolt-slash" color="success">
+          <Card fullWidth>
+            标签内容 #2 (同步 2)
+          </Card>
+        </SuiTabItem>
+      </SuiTabs>
+      <Divider>不同元素</Divider>
+      <SuiTabs syncKey="sync-example">
+        <SuiTabItem label="标签 #3 (同步 1)" icon="bolt">
+          <Card fullWidth>
+            标签内容 #3 (同步 1)
+          </Card>
+        </SuiTabItem>
+        <SuiTabItem label="标签 #4 (同步 2)" icon="bolt-slash" color="success">
+          <Card fullWidth>
+            标签内容 #4 (同步 2)
+          </Card>
+        </SuiTabItem>
+      </SuiTabs>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "syncKey='sync-example'" showLinenumbers title="TabsSyncExample.astro"
+    ---
+    import { Tabs, TabItem, Card, Divider } from 'studiocms:ui/components';
+    ---
+
+    <Tabs syncKey='sync-example'>
+      <TabItem label='标签 #1 (同步 1)' icon='bolt'>
+        <Card fullWidth>
+          标签内容 #1 (同步 1)
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #2 (同步 2)' icon='bolt-slash' color='success'>
+        <Card fullWidth>
+          标签内容 #2 (同步 2)
+        </Card>
+      </TabItem>
+    </Tabs>
+    <Divider>不同元素</Divider>
+    <Tabs syncKey='sync-example'>
+      <TabItem label='标签 #3 (同步 1)' icon='bolt'>
+        <Card fullWidth>
+          标签内容 #3 (同步 1)
+        </Card>
+      </TabItem>
+      <TabItem label='标签 #4 (同步 2)' icon='bolt-slash' color='success'>
+        <Card fullWidth>
+          标签内容 #4 (同步 2)
+        </Card>
+      </TabItem>
+    </Tabs>
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/components/textarea.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/textarea.mdx
@@ -1,0 +1,77 @@
+---
+i18nReady: true
+title: Textarea
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Textarea } from 'studiocms:ui/components';
+
+一个简单的 textarea 组件，支持便捷的标签和占位符。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Textarea label="Label" placeholder="Placeholder" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="TextareaExample.astro"
+    ---
+    import { Textarea } from 'studiocms:ui/components';
+    ---
+
+    <Textarea label='Label' placeholder='Placeholder' />
+    ```
+  </TabItem>
+</Tabs>
+
+### 禁用
+
+你可以使用 `disabled` 属性完全禁用 textarea。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Textarea label="Label" placeholder="Placeholder" disabled />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "disabled" showLinenumbers title="DisabledTextareaExample.astro"
+    ---
+    import { Textarea } from 'studiocms:ui/components';
+    ---
+
+    <Textarea label='Label' placeholder='Placeholder' disabled />
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+Textarea 拥有完整的表单支持。你可以根据需要使用 `isRequired` 和 `name` 属性。
+
+前者正如其名，而后者用于设置 `name` 属性，以便你可以在例如提交返回的 `FormData` 中访问该 textarea。以下是一个展示如何设置这两者的示例：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Textarea label="Label" placeholder="Placeholder" isRequired name="example-textarea" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "isRequired" "name='example-textarea'" showLinenumbers title="FormTextareaExample.astro"
+    ---
+    import { Textarea } from 'studiocms:ui/components';
+    ---
+
+    <Textarea label='Label' placeholder='Placeholder' isRequired name='example-textarea' />
+    ```
+  </TabItem>
+</Tabs>
+
+:::note
+如果未设置名称，则会为该组件生成一个随机名称。
+:::

--- a/docs/src/content/docs/zh-cn/docs/components/theme-toggle.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/theme-toggle.mdx
@@ -1,0 +1,49 @@
+---
+i18nReady: true
+title: 主题切换
+---
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { ThemeToggle, Icon } from 'studiocms:ui/components';
+
+一个简单但实用的辅助组件，您可以将其用作主题切换器。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <ThemeToggle>
+        <Icon name='moon' width={24} height={24} slot="dark" />
+        <Icon name='sun' width={24} height={24} slot="light" />
+      </ThemeToggle>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ThemeToggleExample.astro"
+    ---
+    import { ThemeToggle, Icon } from 'studiocms:ui/components';
+    ---
+
+    <ThemeToggle>
+      <div slot='dark'>
+        {/* 当主题为深色模式时将显示此处的内容！ */}
+        <Icon name='moon' width={24} height={24} slot="dark" />
+      </div>
+      <div slot='light'>
+        {/* 当主题为浅色模式时将显示此处的内容！ */}
+        <Icon name='sun' width={24} height={24} slot="light" />
+      </div>
+    </ThemeToggle>
+    ```
+  </TabItem>
+</Tabs>
+
+### 扩展切换器
+
+`<ThemeToggle />` 组件实际上只是一个带有两个插槽的按钮。您可以传递来自 <a href="/customizing/studiocms-ui/components/button/">`<Button />` 组件</a> 的所有属性，它们将应用于切换器。
+
+:::danger
+`<ThemeToggle />` 元素具有唯一的 ID，应在整个页面上仅使用一次，例如在导航栏中。
+如果您需要多个切换器，请考虑使用 <a href="/customizing/studiocms-ui/components/theme-helper/">`ThemeHelper`</a> 创建您自己的切换器。
+:::

--- a/docs/src/content/docs/zh-cn/docs/components/toast.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/toast.mdx
@@ -1,0 +1,155 @@
+---
+i18nReady: true
+title: Toast
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import ToasterScript from '~/components/ToasterScript.astro';
+import { Toaster, Button, Row } from 'studiocms:ui/components';
+
+:::caution[需要辅助函数]
+此组件需要使用**辅助函数**。请务必仔细阅读文档，以了解如何使用它。
+:::
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Button color="primary" id="usage-trigger">
+        显示 Toast
+      </Button>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ToastExample.astro"
+    ---
+    import { Toaster, Button } from 'studiocms:ui/components';
+    ---
+
+    <!-- 将此添加到页面根目录： -->
+    <Toaster />
+    
+    <Button color='primary' id='trigger'>
+      显示 Toast
+    </Button>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { toast } from 'studiocms:ui/components';
+
+    const trigger = document.getElementById('usage-trigger')!;
+    trigger.addEventListener('click', () => {
+      toast({
+        title: '这是一个 Toast！',
+        description: '你好！',
+        type: 'info',
+      });
+    });
+    ```
+  </TabItem>
+</Tabs>
+
+### 位置
+
+您可以通过 `<Toaster />` 组件上的 `position` 属性更改所有 Toast 的显示位置：
+
+```astro /position='[a-z-]+'/ showLinenumbers title="ToastPosition.astro"
+---
+import { Toaster } from 'studiocms:ui/components';
+---
+
+<Toaster position='top-left' />
+<Toaster position='top-center' />
+<Toaster position='top-right' />
+<Toaster position='bottom-left' />
+<Toaster position='bottom-center' />
+<Toaster position='bottom-right' />
+```
+
+### 持续时间
+
+设置 Toast 持续时间有两种方法：通过 `<Toaster />` 组件上的默认值，或通过 `toast({ ... })` 函数。
+
+您可以像这样设置默认持续时间：
+
+```astro "duration={10000}" showLinenumbers title="ToastDuration.astro"
+---
+import { Toaster } from 'studiocms:ui/components';
+---
+
+<Toaster duration={10000} />
+```
+
+或者，您可以为每个 Toast 单独设置：
+
+```ts "duration: 10000" twoslash showLinenumbers title="ToastDuration.ts"
+// @noErrors
+import { toast } from 'studiocms:ui/components';
+
+toast({
+  title: '这是一个 Toast！',
+  description: '你好！',
+  type: 'info',
+  duration: 10000
+});
+```
+
+### 持久化
+
+有时，您不需要 Toast 在设定的时间后消失。与其将 Toast 设置为 31 天后过期，不如通过将 `persistent` 设置为 `true` 使其持久化：
+
+```ts "persistent: true" twoslash showLinenumbers title="ToastPersistence.ts"
+// @noErrors
+import { toast } from 'studiocms:ui/components';
+
+toast({
+  title: '这是一个 Toast！',
+  description: '你好！',
+  type: 'info',
+  persistent: true
+});
+```
+
+### 关闭按钮
+
+除非 Toast 是持久化的，否则您可以通过将 `closeButton` 选项设置为 `false` 来隐藏关闭按钮：
+
+```ts "closeButton: false" twoslash showLinenumbers title="ToastCloseButton.ts"
+// @noErrors
+import { toast } from 'studiocms:ui/components';
+
+toast({
+  title: '这是一个 Toast！',
+  description: '你好！',
+  type: 'info',
+  closeButton: false
+});
+```
+
+### 偏移量和间距
+
+您可以通过更改 `<Toaster />` 上的 `offset` 属性来调整 Toast 距离屏幕边缘的距离：
+
+```astro showLinenumbers title="ToastOffset.astro"
+---
+import { Toaster } from 'studiocms:ui/components';
+---
+
+<!-- 以像素为单位的偏移量 -->
+<Toaster offset={64} />
+```
+
+您还可以通过 `<Toaster />` 上的 `gap` 属性更改 Toast 之间的间距：
+
+```astro showLinenumbers title="ToastGap.astro"
+---
+import { Toaster } from 'studiocms:ui/components';
+---
+
+<!-- 以像素为单位的间距 -->
+<Toaster gap={32} />
+```
+
+<ToasterScript />

--- a/docs/src/content/docs/zh-cn/docs/components/toggle.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/toggle.mdx
@@ -1,0 +1,125 @@
+---
+i18nReady: true
+title: 开关
+sidebar:
+  badge:
+    text: New Colors！
+    variant: tip
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { Toggle, Row } from 'studiocms:ui/components';
+
+一个支持多种尺寸和颜色的开关组件。与表单兼容。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Toggle label="标签" color="primary" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="ToggleExample.astro"
+    ---
+    import { Toggle } from 'studiocms:ui/components';
+    ---
+
+    <Toggle label='标签' color='primary' />
+    ```
+  </TabItem>
+</Tabs>
+
+### 尺寸
+
+开关有三种不同的尺寸：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Row>
+        <Toggle label="小" color="primary" size="sm" defaultChecked />
+        <Toggle label="中" color="primary" defaultChecked />
+        <Toggle label="大" color="primary" size="lg" defaultChecked />
+      </Row>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /size='[a-z]+'/ showLinenumbers title="ToggleSizesExample.astro"
+    ---
+    import { Toggle } from 'studiocms:ui/components';
+    ---
+
+    <Toggle label='小' color='primary' size='sm' defaultChecked />
+    <Toggle label='中' color='primary' defaultChecked />
+    <Toggle label='大' color='primary' size='lg' defaultChecked />
+    ```
+  </TabItem>
+</Tabs>
+
+### 颜色
+
+开关组件支持所有默认配色方案。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Toggle label="默认" defaultChecked />
+      <Toggle label="主色" color="primary" defaultChecked />
+      <Toggle label="成功" color="success" defaultChecked />
+      <Toggle label="警告" color="warning" defaultChecked />
+      <Toggle label="危险" color="danger" defaultChecked />
+      <Toggle label="信息" color="info" defaultChecked />
+      <Toggle label="单色" color="mono" defaultChecked />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro /color="[a-z]+"/ showLinenumbers title="ToggleColorsExample.astro"
+    ---
+    import { Toggle } from 'studiocms:ui/components';
+    ---
+
+    <Toggle label='默认' defaultChecked />
+    <Toggle label='主色' color='primary' defaultChecked />
+    <Toggle label='成功' color='success' defaultChecked />
+    <Toggle label='警告' color='warning' defaultChecked />
+    <Toggle label='危险' color='danger' defaultChecked />
+    <Toggle label="信息" color="info" defaultChecked />
+    <Toggle label="单色" color="mono" defaultChecked />
+    ```
+  </TabItem>
+</Tabs>
+
+### 表单支持
+
+如果您想在表单中使用此组件，您很幸运！您可以传递两个属性：`isRequired` 和 `name`。
+
+前者如其名所示会执行相应的操作，后者则设置 `name` 属性，以便您可以访问该开关，例如在提交返回的 `FormData` 中。以下是一个展示如何设置这两个属性的示例：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <Toggle label="必填 & 自定义名称" color="primary" isRequired name='example' />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro ins={8-9} showLinenumbers title="ToggleFormExample.astro"
+    ---
+    import { Toggle } from 'studiocms:ui/components';
+    ---
+
+    <Toggle 
+      label='必填 & 自定义名称'
+      color='primary'
+      isRequired
+      name='example'
+    />
+    ```
+  </TabItem>
+</Tabs>
+
+:::note
+如果未设置名称，则会为该组件生成一个随机名称。
+:::

--- a/docs/src/content/docs/zh-cn/docs/components/user.mdx
+++ b/docs/src/content/docs/zh-cn/docs/components/user.mdx
@@ -1,0 +1,53 @@
+---
+i18nReady: true
+title: 用户
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import { User } from 'studiocms:ui/components';
+import Avatar from '~/assets/avatar.png'
+
+用于显示用户信息的组件。
+
+## 用法
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <User name="John Doe" description="A cool dude" />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro showLinenumbers title="UserExample.astro"
+    ---
+    import { User } from 'studiocms:ui/components';
+    ---
+
+    <User name='John Doe' description='A cool dude' />
+    ```
+  </TabItem>
+</Tabs>
+
+### 头像
+
+您可以按照与 [`Image`](https://docs.astro.build/en/guides/images/#src-required) 组件相同的规则提供 `avatar`。
+要更改加载行为，您可以传递 `loading` 属性。该属性会被传递给 `<Image />` 组件。
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <User name="John Doe" loading='eager' description="A cool dude" avatar={Avatar} />
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```astro "avatar={ProfileImage}" "loading='eager'" showLinenumbers title="UserAvatarExample.astro"
+    ---
+    import { User } from 'studiocms:ui/components';
+    import ProfileImage from '~/assets/profile.png'
+    ---
+
+    <User name='John Doe' loading='eager' description='A cool dude' avatar={ProfileImage} />
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/zh-cn/docs/guides/customization.mdx
+++ b/docs/src/content/docs/zh-cn/docs/guides/customization.mdx
@@ -1,0 +1,202 @@
+---
+i18nReady: true
+title: 自定义 StudioCMS UI
+---
+
+StudioCMS UI 基于 CSS 变量设计，这使得自定义组件的外观以匹配你的项目变得非常简单。你可以自定义颜色、排版、圆角等。所有的自定义都通过一个自定义 CSS 文件完成，你可以将其提供给 UI 集成：
+
+```ts showLinenumbers title="astro.config.mjs" {7}
+import { defineConfig } from 'astro/config';
+import ui from '@studiocms/ui';
+
+export default defineConfig({
+  integrations: [
+    ui({
+      customCss: './path/to/custom.css'
+    })
+  ]
+});
+```
+
+在该文件中，你可以覆盖 CSS 变量以更改组件的外观。如果你想覆盖主色，它看起来像这样：
+
+```css showLinenumbers title="custom.css"
+:root {
+	--primary-base: 0 0% 100%;
+	--primary-hover: 0 0% 80%;
+	--primary-active: 0 0% 90%;
+}
+
+[data-theme='light'] :root {
+	--primary-base: 0 0% 0%;
+	--primary-hover: 0 0% 20%;
+	--primary-active: 0 0% 10%;
+}
+```
+
+如果你对颜色进行了重大更改，请记得同时调整浅色主题。
+
+下面，你会找到 StudioCMS UI 中使用的所有 CSS 变量。请务必以不带逗号的 HSL 值提供它们。你可以像这样在 CSS 中使用它们：`background-color: hsl(var(--background-base));`。
+
+## 禁用 CSS 注入
+
+如果你想禁用 CSS 注入，可以通过将 `noInjectCSS` 选项设置为 `true` 来实现：
+
+```ts twoslash showLinenumbers title="astro.config.mjs" {7}
+import { defineConfig } from 'astro/config';
+import ui from '@studiocms/ui';
+
+export default defineConfig({
+  integrations: [
+    ui({
+      noInjectCSS: true,
+    })
+  ]
+});
+```
+
+然后你可以手动将 CSS 包含到你的项目中。如果你想将 StudioCMS UI 与其他 CSS 框架混合使用，或者你仅在部分组件中使用 UI 样式，这将非常有用。
+
+```astro showLinenumbers title="src/layouts/SUILayout.astro"
+---
+// 使用虚拟模块导入 CSS 文件（推荐）
+import "studiocms:ui/global-css";
+
+// 或者，直接从包中导入 CSS 文件
+import "@studiocms/ui/css/global.css";
+---
+```
+
+## 交互式编辑
+
+在开发过程中，你可以使用开发工具栏在自己的项目中编辑颜色。在工具栏中，你会找到一个带有 StudioCMS 标志的标签。点击后，它会显示一些颜色选择器和输入框，你可以用它们来调整各种变量。完成后，你可以将更改复制到剪贴板。
+
+import { Accordion, AccordionItem } from 'studiocms:ui/components';
+
+## 颜色变量
+
+<Accordion>
+	<AccordionItem>
+		<div slot="summary">深色模式</div>
+		<div>
+
+| 变量 | 描述 | 默认值 |
+| --- | --- | --- |
+| `--background-base` | 基础背景色 | `0 0% 6%` |
+| `--background-step-1` | 背景色步骤 1 | `0 0% 8%` |
+| `--background-step-2` | 背景色步骤 2 | `0 0% 10%` |
+| `--background-step-3` | 背景色步骤 3 | `0 0% 14%` |
+| `--text-normal` | 正常文本颜色 | `0 0% 100%` |
+| `--text-muted` | 弱化文本颜色 | `0 0% 54%` |
+| `--text-inverted` | 反转文本颜色 | `0 0% 0%` |
+| `--border` | 边框颜色 | `240 5% 17%` |
+| `--shadow` | 阴影颜色 | `0 0% 0%` |
+| `--default-base` | 默认颜色基础 | `0 0% 14%` |
+| `--default-hover` | 默认颜色悬停 | `0 0% 21%` |
+| `--default-active` | 默认颜色激活 | `0 0% 15%` |
+| `--primary-base` | 主色基础 | `259 83% 73%` |
+| `--primary-hover` | 主色悬停 | `259 77% 78%` |
+| `--primary-active` | 主色激活 | `259 73% 67%` |
+| `--success-base` | 成功颜色基础 | `142 71% 46%` |
+| `--success-hover` | 成功颜色悬停 | `142 72% 61%` |
+| `--success-active` | 成功颜色激活 | `142 87% 52%` |
+| `--warning-base` | 警告颜色基础 | `48 96% 53%` |
+| `--warning-hover` | 警告颜色悬停 | `48 97% 70%` |
+| `--warning-active` | 警告颜色激活 | `48 100% 61%` |
+| `--danger-base` | 危险颜色基础 | `339 97% 31%` |
+| `--danger-hover` | 危险颜色悬停 | `337 98% 37%` |
+| `--danger-active` | 危险颜色激活 | `337 88% 32%` |
+| `--info-base` | 信息颜色基础 | `217 92% 52%` |
+| `--info-hover` | 信息颜色悬停 | `214 95% 58%` |
+| `--info-active` | 信息颜色激活 | `214 85% 52%` |
+| `--mono-base` | 单色基础 | `0 0% 100%` |
+| `--mono-hover` | 单色悬停 | `0 0% 90%` |
+| `--mono-active` | 单色激活 | `0 0% 95%` |
+
+		</div>
+	</AccordionItem>
+
+	<AccordionItem>
+		<div slot="summary">浅色模式</div>
+		<div>
+
+| 变量 | 描述 | 默认值 |
+| --- | --- | --- |
+| `--background-base` | 基础背景色 | `0 0% 97%` |
+| `--background-step-1` | 背景色步骤 1 | `0 0% 90%` |
+| `--background-step-2` | 背景色步骤 2 | `0 0% 85%` |
+| `--background-step-3` | 背景色步骤 3 | `0 0% 80%` |
+| `--text-normal` | 正常文本颜色 | `0 0% 0%` |
+| `--text-muted` | 弱化文本颜色 | `0 0% 24%` |
+| `--text-inverted` | 反转文本颜色 | `0 0% 100%` |
+| `--border` | 边框颜色 | `263 5% 68%` |
+| `--shadow` | 阴影颜色 | `0 0% 65%` |
+| `--default-base` | 默认颜色基础 | `0 0% 74%` |
+| `--default-hover` | 默认颜色悬停 | `0 0% 81%` |
+| `--default-active` | 默认颜色激活 | `0 0% 91%` |
+| `--primary-base` | 主色基础 | `259 85% 61%` |
+| `--primary-hover` | 主色悬停 | `259 78% 56%` |
+| `--primary-active` | 主色激活 | `259 71% 50%` |
+| `--success-base` | 成功颜色基础 | `142 59% 47%` |
+| `--success-hover` | 成功颜色悬停 | `142 62% 56%` |
+| `--success-active` | 成功颜色激活 | `142 87% 59%` |
+| `--warning-base` | 警告颜色基础 | `48 92% 46%` |
+| `--warning-hover` | 警告颜色悬停 | `48 88% 43%` |
+| `--warning-active` | 警告颜色激活 | `48 85% 40%` |
+| `--danger-base` | 危险颜色基础 | `339 97% 31%` |
+| `--danger-hover` | 危险颜色悬停 | `337 98% 37%` |
+| `--danger-active` | 危险颜色激活 | `337 88% 45%` |
+| `--info-base` | 信息颜色基础 | `217 92% 52%` |
+| `--info-hover` | 信息颜色悬停 | `214 95% 58%` |
+| `--info-active` | 信息颜色激活 | `214 85% 52%` |
+| `--mono-base` | 单色基础 | `0 0% 0%` |
+| `--mono-hover` | 单色悬停 | `0 0% 10%` |
+| `--mono-active` | 单色激活 | `0 0% 5%` |
+
+		</div>
+	</AccordionItem>
+
+	<AccordionItem>
+		<div slot="summary">非主题颜色变量</div>
+		<div>
+
+| 变量 | 描述 | 默认值 |
+| --- | --- | --- |
+| `--text-light` | 浅色文本颜色 | `0 0% 100%` |
+| `--text-dark` | 深色文本颜色 | `0 0% 0%` |
+| `--default-flat` | 默认平面颜色 | `var(--default-base) / 0.5` |
+| `--default-flat-hover` | 默认平面悬停颜色 | `var(--default-base) / 0.75` |
+| `--default-flat-active` | 默认平面激活颜色 | `var(--default-base) / 0.85` |
+| `--primary-flat` | 主色平面颜色 | `var(--primary-base) / 0.1` |
+| `--primary-flat-hover` | 主色平面悬停颜色 | `var(--primary-base) / 0.25` |
+| `--primary-flat-active` | 主色平面激活颜色 | `var(--primary-base) / 0.35` |
+| `--success-flat` | 成功平面颜色 | `var(--success-base) / 0.1` |
+| `--success-flat-hover` | 成功平面悬停颜色 | `var(--success-base) / 0.25` |
+| `--success-flat-active` | 成功平面激活颜色 | `var(--success-base) / 0.35` |
+| `--warning-flat` | 警告平面颜色 | `var(--warning-base) / 0.1` |
+| `--warning-flat-hover` | 警告平面悬停颜色 | `var(--warning-base) / 0.25` |
+| `--warning-flat-active` | 警告平面激活颜色 | `var(--warning-base) / 0.35` |
+| `--danger-flat` | 危险平面颜色 | `var(--danger-base) / 0.1` |
+| `--danger-flat-hover` | 危险平面悬停颜色 | `var(--danger-base) / 0.25` |
+| `--danger-flat-active` | 危险平面激活颜色 | `var(--danger-base) / 0.35` |
+| `--info-flat` | 信息平面颜色 | `var(--info-base) / 0.1` |
+| `--info-flat-hover` | 信息平面悬停颜色 | `var(--info-base) / 0.25` |
+| `--info-flat-active` | 信息平面激活颜色 | `var(--info-base) / 0.35` |
+
+		</div>
+	</AccordionItem>
+
+	<AccordionItem>
+		<div slot="summary">圆角变量</div>
+		<div>
+
+| 变量 | 描述 | 默认值 |
+| --- | --- | --- |
+| `--radius-sm` | 小圆角 | `.25rem` |
+| `--radius-md` | 中圆角 | `.5rem` |
+| `--radius-lg` | 大圆角 | `1rem` |
+| `--radius-full` | 全圆角 | `999px` |
+
+		</div>
+	</AccordionItem>
+</Accordion>

--- a/docs/src/content/docs/zh-cn/docs/index.mdx
+++ b/docs/src/content/docs/zh-cn/docs/index.mdx
@@ -1,0 +1,96 @@
+---
+i18nReady: true
+title: "快速开始"
+description: 安装 @studiocms/ui 到你的项目中并使用我们的组件！
+type: integration
+integration:
+  name: "@studiocms/ui"
+  githubURL: "https://github.com/withstudiocms/ui/tree/main/packages/studiocms_ui"
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+
+:::danger[无障碍]
+`@studiocms/ui` 尚未经过无障碍审计。你可以在 GitHub 上的[无障碍性问题跟踪器](https://github.com/withstudiocms/ui/issues/19)中查看我们的进展。
+:::
+
+`@studiocms/ui` 是我们用来构建 StudioCMS 的 UI 库。该库是无框架依赖的，这意味着你可以在自己的 Astro 项目中使用它！
+
+要开始使用，请将该集成添加到你的项目中。
+
+<PackageManagers type="exec" pkg="astro add @studiocms/ui" />
+
+<details>
+<summary>在 Astro 4 中使用 `@studiocms/ui`</summary>
+
+StudioCMS UI 可以在 Astro 5 中直接使用，无需额外配置。而在 Astro v4 中，`@studiocms/ui` 需要版本 `v4.5.0` 或更高，并启用 `experimental.directRenderScript` 标志。
+</details>
+
+## 手动安装
+
+使用你喜欢的包管理器安装 `@studiocms/ui` 包。
+
+<PackageManagers type="add" pkg="@studiocms/ui" />
+
+在你的 Astro 配置中导入并使用 `@studiocms/ui` 集成。
+
+```ts showLinenumbers title="astro.config.mjs" {2,6}
+import { defineConfig } from 'astro/config';
+import ui from '@studiocms/ui';
+
+export default defineConfig({
+  integrations: [
+    ui()
+  ]
+});
+```
+
+## 导入组件
+
+该库中的所有组件都从 `@studiocms/ui/components` 导出。你可以像下面这样导入并使用这些组件：
+
+```astro showLinenumbers title="ButtonExample.astro"
+---
+import { Button } from 'studiocms:ui/components';
+---
+
+<Button />
+```
+
+## 配合 Tailwind 使用 `@studiocms/ui`
+
+如果你还没有这样做，请将 Astro 的 Tailwind 集成添加到你的项目中。
+
+<PackageManagers type="exec" pkg="astro add tailwind" />
+
+通过 `applyBaseStyles: false` 禁用 [Tailwind 的预设样式](https://tailwindcss.com/docs/preflight)。
+
+```ts showLinenumbers title="astro.config.mjs" "applyBaseStyles: false"
+import { defineConfig } from 'astro/config';
+import ui from '@studiocms/ui';
+
+export default defineConfig({
+  integrations: [
+    ui(),
+    tailwind({ applyBaseStyles: false })
+  ]
+});
+```
+
+为 Tailwind 的基础样式创建一个 CSS 文件。例如 `src/styles/tailwind.css`。
+
+```css showLinenumbers title="src/styles/tailwind.css"
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+在任何使用 Tailwind 的布局或页面中导入此 CSS 文件。
+
+```astro showLinenumbers title="src/layouts/Base.astro"
+---
+import '../styles/tailwind.css';
+
+// ...
+---
+```

--- a/docs/src/content/docs/zh-cn/docs/showcase.mdx
+++ b/docs/src/content/docs/zh-cn/docs/showcase.mdx
@@ -1,0 +1,21 @@
+---
+i18nReady: true
+title: "网站展示"
+description: "查看其他人使用 StudioCMS UI 库 构建的网站。"
+editUrl: false
+---
+
+:::tip[添加你的网站！]
+你使用过 `@studiocms/ui` 构建网站吗？
+[发起 PR](https://github.com/withstudiocms/ui/blob/main/docs/src/content/showcase.json) 将你的网站添加到展示中！
+:::
+
+## 网站
+
+import ShowcaseSites from '~/components/showcase-sites.astro';
+
+**`@studiocms/ui`** 已在生产环境中使用。以下是一些使用该库构建的网站示例：
+
+<ShowcaseSites />
+
+查看所有在 GitHub 上使用 `@studiocms/ui` 的[公开项目仓库](https://github.com/withstudiocms/ui/network/dependents)。

--- a/docs/src/content/docs/zh-cn/docs/upgrade-guides/0.1.0-to-0.3.0.mdx
+++ b/docs/src/content/docs/zh-cn/docs/upgrade-guides/0.1.0-to-0.3.0.mdx
@@ -1,0 +1,35 @@
+---
+title: From v0.1 to v0.3
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+Version 0.3.0 of `@studiocms/ui` introduced mostly accessibility improvements and is backwards compatible. 
+
+While there are no breaking changes, **the method of importing the `global.css` stylesheet in the root layout 
+has been deprecated in favor of using the provided integration.**
+
+We recommend doing the following to upgrade your project:
+
+<Steps>
+1.  Remove the `global.css` import from your root layout.
+    ```astro showlinenumbers del={2} title="Layout.astro"
+    ---
+    import '@studiocms/ui/css/global.css';
+    ---
+    ```
+
+2.  Add the following code to your `astro.config.mjs` file:
+    ```ts showLinenumbers title="astro.config.mjs" {2,6}
+    import { defineConfig } from 'astro/config';
+    import ui from '@studiocms/ui';
+
+    export default defineConfig({
+      integrations: [
+        ui()
+      ]
+    });
+    ```
+</Steps>
+
+The integration will automatically add the stylesheet to your page.

--- a/docs/src/content/docs/zh-cn/docs/upgrade-guides/0.3-to-0.4.mdx
+++ b/docs/src/content/docs/zh-cn/docs/upgrade-guides/0.3-to-0.4.mdx
@@ -1,0 +1,18 @@
+---
+title: From v0.3 to v0.4
+---
+
+In v0.3 of StudioCMS UI, we turned the library into an Astro integration. With v0.4, we're building on that foundation to fix some critical issues and further improve the developer experience. Here's what you'll have to do to migrate your existing projects:
+
+## New Imports
+
+In order to remove issues with script and style leakage, we've updated all imports to use virtual modules instead of barrel files. This means that you will have to change all of your imports for all components:
+
+```astro del={2} ins={3}
+---
+import { Button } from '@studiocms/ui/components';
+import { Button } from 'studiocms:ui/components';
+---
+```
+
+We recommend simply bulk-replacing `@studiocms/ui/` with `studiocms:ui/`.

--- a/docs/src/content/docs/zh-cn/docs/utilities/theme-helper.mdx
+++ b/docs/src/content/docs/zh-cn/docs/utilities/theme-helper.mdx
@@ -1,0 +1,112 @@
+---
+i18nReady: true
+title: Theme Helper
+---
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import PreviewCard from '~/components/PreviewCard.astro';
+import ThemeHelperScript from '~/components/ThemeHelperScript.astro';
+
+为了更轻松地管理活动主题，我们提供了一个辅助类来获取、设置和切换主题。此外，您还可以提供主题更改时的回调！
+
+## 用法
+
+:::caution
+`ThemeHelper` 只能在客户端使用（在 `<script>` 标签中）。
+:::
+```ts title="script.ts" twoslash showLinenumbers
+// @noErrors
+import { ThemeHelper } from 'studiocms:ui/utils';
+
+// 实例化一个新的辅助器
+const themeHelper = new ThemeHelper();
+
+// 获取当前主题。（`dark`、`light` 或 `system` 之一）
+const theme = themeHelper.getTheme();
+
+// 获取当前主题，但如果选择了 `system`，则解析实际主题
+const resolvedTheme = themeHelper.getTheme(true);
+
+// 将主题设置为亮色
+themeHelper.setTheme('light');
+
+// 切换主题
+themeHelper.toggleTheme();
+
+// 注册一个应作为切换开关的元素
+const toggleButton = document.querySelector<HTMLButtonElement>('#toggle-button');
+themeHelper.registerToggle(toggleButton);
+```
+
+### 监听主题更改
+
+使用 `ThemeHelper` 类，您可以监听主题更改！当您的逻辑需要在颜色方案更改时运行时，这很有用，例如在 `three.js` 画布中，您需要更改图像（*咳咳*，我们的登录页面 *咳咳*）。
+
+```ts title="script.ts" twoslash showLinenumbers
+// @noErrors
+import { ThemeHelper } from 'studiocms:ui/utils';
+
+// 实例化一个新的辅助器
+const themeHelper = new ThemeHelper();
+
+// 添加一个主题更改时调用的回调
+themeHelper.onThemeChange((newTheme) => {
+  // 您的逻辑放在这里！
+});
+```
+
+这是一个实时示例：通过屏幕右上角的选项更改主题。如果您使用的是移动设备，请打开导航栏并滚动到底部。更改主题后，请检查下面的文本：
+
+<Tabs>
+  <TabItem label="预览">
+    <PreviewCard>
+      <span id="theme-listener-output">
+        主题尚未更改。
+      </span>
+    </PreviewCard>
+  </TabItem>
+  <TabItem label="代码">
+    ```html showLinenumbers
+    <span id='theme-listener-output'>
+      主题尚未更改。
+    </span>
+    ```
+    ```ts twoslash showLinenumbers title="Script Tag"
+    // @noErrors
+    import { ThemeHelper, type Theme } from 'studiocms:ui/utils';
+
+    // 实例化一个新的辅助器
+    const themeHelper = new ThemeHelper();
+
+    const outputSpan = document.querySelector<HTMLSpanElement>('#theme-listener-output')!;
+
+    // 添加一个主题更改时调用的回调
+    themeHelper.onThemeChange((newTheme: Theme, oldTheme: Theme) => {
+      // 您的逻辑放在这里！
+      outputSpan.textContent = `主题现在是：${newTheme}！（之前：${oldTheme}）`;
+    });
+    ```
+  </TabItem>
+</Tabs>
+
+由于 `@studiocms/ui` 与 Starlight 的主题系统兼容，这甚至可以检测到这些更改。
+
+### 记住用户的主题选择
+
+`ThemeHelper` 唯一不做的几件事之一就是保存用户的主题偏好。这是有意为之的，因为我们不想迫使在欧盟（和其他执行 GDPR 的国家）运营的网站仅仅为了一个 UI 库就必须添加 cookie 通知。相反，此功能的实现由开发者自己决定。
+
+作为起点，这是一个如何实现此功能的简单示例：
+
+```ts twoslash showLinenumbers title="Script Tag"
+// @noErrors
+import { ThemeHelper, type Theme } from 'studiocms:ui/utils';
+
+const themeHelper = new ThemeHelper();
+
+themeHelper.onThemeChange((newTheme: Theme) => {
+  localStorage.setItem('theme-selection', newTheme);
+});
+```
+
+如果您想进一步，可以将此信息存储在 cookie 中，以便在服务器端检索它。
+
+<ThemeHelperScript />


### PR DESCRIPTION
Enabled zh-cn locale in astro.config.mts and added documentation for all UI components, guides, and utilities in Simplified Chinese under docs/src/content/docs/zh-cn/docs/. This includes changelog, component usage guides, customization, showcase, and upgrade guides for the StudioCMS UI package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Chinese (zh-CN) language documentation covering all UI components, guides, utilities, and upgrade instructions
  * Enabled Chinese locale support in configuration for improved accessibility to Chinese-speaking users

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->