### PR TITLE
fix: Adjust footer CSS

### DIFF
--- a/.changeset/short-bikes-talk.md
+++ b/.changeset/short-bikes-talk.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/ui": patch
+---
+
+Adjusts footer CSS to no longer display mobile version on devices with a 13" screen

--- a/packages/studiocms_ui/src/components/Footer/footer.css
+++ b/packages/studiocms_ui/src/components/Footer/footer.css
@@ -67,7 +67,7 @@ footer.sui-footer {
 	}
 }
 
-@media screen and (max-width: 1280px) {
+@media screen and (max-width: 1024px) {
 	.upper {
 		flex-direction: column;
 		gap: 2rem;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Adjusts the footer CSS slightly by moving a breakpoint to a lower value. This prevents the footer from showing in mobile mode on devices with a 13" screen.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated footer responsive breakpoint so the upper layout switches to column at narrower screen widths (delays mobile layout until smaller viewports).

* **Chores**
  * Added a release note/changeset recording this footer behavior adjustment for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->